### PR TITLE
Update theme from lavender to electric blue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,10 +89,10 @@ const App = () => {
             {/* Brand Name */}
             <div className="space-y-4">
               <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold font-heading electric-text-gradient leading-tight">
-                NNC GAMES
+                GAME HUB
               </h1>
               <p className="text-lg sm:text-xl md:text-2xl font-medium text-gray-700 font-body">
-                Modern Gaming Platform
+                BY NNC GAMES
               </p>
             </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,47 +38,113 @@ const App = () => {
     };
   }, []);
 
-  // Modern Electric Blue Loading Screen
+  // Ultra-Modern Professional Gaming Loading Experience
   if (appLoading) {
     return (
       <div className="fixed inset-0 overflow-hidden font-body">
-        {/* Dynamic Electric Blue Background */}
-        <div className="absolute inset-0 electric-gradient">
-          <div className="absolute inset-0 bg-gradient-to-br from-white/20 via-transparent to-blue-500/5"></div>
+        {/* Advanced Multi-Layer Background System */}
+        <div className="absolute inset-0">
+          {/* Primary Gradient Layer */}
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900"></div>
+
+          {/* Dynamic Mesh Gradient */}
+          <div className="absolute inset-0 opacity-40">
+            <div
+              className="h-full w-full"
+              style={{
+                backgroundImage: `
+                  radial-gradient(circle at 20% 80%, hsl(205, 100%, 50%) 0%, transparent 50%),
+                  radial-gradient(circle at 80% 20%, hsl(195, 100%, 55%) 0%, transparent 50%),
+                  radial-gradient(circle at 40% 40%, hsl(215, 100%, 45%) 0%, transparent 40%),
+                  conic-gradient(from 180deg at 50% 50%, transparent 0deg, hsl(205, 100%, 50%) 180deg, transparent 360deg)
+                `,
+              }}
+            ></div>
+          </div>
+
+          {/* Animated Particle System */}
+          <div className="absolute inset-0 opacity-20">
+            {[...Array(50)].map((_, i) => (
+              <div
+                key={i}
+                className="absolute w-1 h-1 bg-blue-400 rounded-full"
+                style={{
+                  left: `${Math.random() * 100}%`,
+                  top: `${Math.random() * 100}%`,
+                  animationDelay: `${Math.random() * 3}s`,
+                }}
+              ></div>
+            ))}
+          </div>
+
+          {/* Geometric Pattern Overlay */}
+          <div className="absolute inset-0 opacity-10">
+            <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <pattern
+                  id="grid"
+                  width="40"
+                  height="40"
+                  patternUnits="userSpaceOnUse"
+                >
+                  <path
+                    d="M 40 0 L 0 0 0 40"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                    className="text-blue-300"
+                  />
+                </pattern>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#grid)" />
+            </svg>
+          </div>
         </div>
 
-        {/* Vibrant Pattern Overlay */}
-        <div className="absolute inset-0 opacity-10">
+        {/* Floating Interactive Elements */}
+        <div className="absolute inset-0 pointer-events-none">
+          {/* Floating Orbs */}
           <div
-            className="h-full w-full"
-            style={{
-              backgroundImage: `radial-gradient(circle at 25% 25%, hsl(205, 100%, 50%) 0%, transparent 50%),
-                               radial-gradient(circle at 75% 75%, hsl(195, 100%, 55%) 0%, transparent 50%)`,
-            }}
+            className="absolute top-1/4 left-1/4 w-20 h-20 bg-gradient-to-r from-blue-400/30 to-cyan-400/30 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "0s" }}
+          ></div>
+          <div
+            className="absolute top-3/4 right-1/4 w-16 h-16 bg-gradient-to-r from-purple-400/30 to-blue-400/30 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "1s" }}
+          ></div>
+          <div
+            className="absolute top-1/2 left-3/4 w-12 h-12 bg-gradient-to-r from-cyan-400/30 to-blue-400/30 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "2s" }}
           ></div>
         </div>
 
-        {/* Main Content */}
+        {/* Main Content Container */}
         <div className="relative z-10 flex flex-col items-center justify-center min-h-screen p-6 sm:p-8">
-          <div className="text-center space-y-8 sm:space-y-10 max-w-md sm:max-w-lg mx-auto w-full">
-            {/* Modern Logo */}
-            <div className="relative">
-              <div className="electric-shadow-lg rounded-full p-2">
-                <div className="electric-glass rounded-full p-8 sm:p-10 backdrop-blur-xl">
-                  <div className="w-16 h-16 sm:w-20 sm:h-20 mx-auto mb-4 relative">
-                    <div className="absolute inset-0 bg-gradient-to-br from-blue-500 to-blue-600 rounded-2xl electric-pulse"></div>
-                    <div className="absolute inset-2 bg-white rounded-xl flex items-center justify-center">
+          <div className="text-center space-y-10 sm:space-y-12 max-w-lg sm:max-w-xl mx-auto w-full">
+            {/* Revolutionary Logo Design */}
+            <div className="relative group">
+              {/* Outer Glow Ring */}
+              <div className="absolute -inset-8 bg-gradient-to-r from-blue-500/20 via-purple-500/20 to-cyan-500/20 rounded-full blur-2xl group-hover:blur-3xl transition-all duration-1000"></div>
+
+              {/* Logo Container */}
+              <div className="relative">
+                <div className="electric-glass backdrop-blur-2xl rounded-full p-8 sm:p-12 border border-blue-300/30">
+                  {/* Rotating Border */}
+                  <div className="absolute inset-0 rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-cyan-500 opacity-75 blur-sm"></div>
+                  <div className="absolute inset-0.5 rounded-full bg-slate-900/80 backdrop-blur-xl"></div>
+
+                  {/* Logo Icon */}
+                  <div className="relative w-20 h-20 sm:w-24 sm:h-24 mx-auto">
+                    <div className="absolute inset-0 bg-gradient-to-br from-blue-400 via-purple-500 to-cyan-400 rounded-3xl electric-pulse transform rotate-45"></div>
+                    <div className="absolute inset-3 bg-gradient-to-br from-white to-blue-50 rounded-2xl flex items-center justify-center transform -rotate-45">
                       <svg
-                        className="w-8 h-8 sm:w-10 sm:h-10 text-blue-600"
+                        className="w-10 h-10 sm:w-12 sm:h-12 text-blue-600"
                         fill="currentColor"
-                        viewBox="0 0 20 20"
+                        viewBox="0 0 24 24"
                       >
-                        <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
-                        <path
-                          fillRule="evenodd"
-                          d="M4 5a2 2 0 012-2h8a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 1a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z"
-                          clipRule="evenodd"
-                        />
+                        <path d="M12 2C13.1 2 14 2.9 14 4V10L16 12L14 14V20C14 21.1 13.1 22 12 22S10 21.1 10 20V14L8 12L10 10V4C10 2.9 10.9 2 12 2Z" />
+                        <circle cx="12" cy="8" r="2" />
+                        <circle cx="12" cy="16" r="2" />
                       </svg>
                     </div>
                   </div>
@@ -86,113 +152,130 @@ const App = () => {
               </div>
             </div>
 
-            {/* Brand Name */}
-            <div className="space-y-4">
-              <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold font-heading electric-text-gradient leading-tight">
-                GAME HUB
-              </h1>
-              <p className="text-lg sm:text-xl md:text-2xl font-medium text-gray-700 font-body">
-                BY NNC GAMES
-              </p>
-            </div>
+            {/* Advanced Typography System */}
+            <div className="space-y-6">
+              {/* Main Title */}
+              <div className="relative">
+                <h1 className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black font-heading leading-none">
+                  <span className="block bg-gradient-to-r from-blue-200 via-white to-cyan-200 bg-clip-text text-transparent drop-shadow-2xl">
+                    GAME
+                  </span>
+                  <span className="block bg-gradient-to-r from-cyan-300 via-blue-300 to-purple-300 bg-clip-text text-transparent electric-text-gradient">
+                    HUB
+                  </span>
+                </h1>
 
-            {/* Modern Loading Spinner */}
-            <div className="relative">
-              <div className="w-12 h-12 sm:w-16 sm:h-16 mx-auto">
-                <div className="electric-spinner w-full h-full"></div>
+                {/* Subtitle with Enhanced Styling */}
+                <div className="mt-4 relative">
+                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-blue-500/20 to-transparent blur-xl"></div>
+                  <p className="relative text-xl sm:text-2xl md:text-3xl font-medium text-blue-200 font-body tracking-widest">
+                    BY
+                    <span className="mx-3 font-black text-white electric-text-gradient">
+                      NNC GAMES
+                    </span>
+                  </p>
+                </div>
               </div>
             </div>
 
-            {/* Progress Bar */}
-            <div className="w-full max-w-sm mx-auto">
-              <div className="relative h-2 bg-gray-200 rounded-full overflow-hidden electric-shadow">
-                <div className="absolute inset-0 electric-shimmer"></div>
+            {/* Sophisticated Loading Animation */}
+            <div className="relative space-y-8">
+              {/* Multi-Ring Spinner */}
+              <div className="relative w-24 h-24 sm:w-28 sm:h-28 mx-auto">
+                <div className="absolute inset-0 rounded-full border-4 border-blue-500/30"></div>
+                <div className="absolute inset-2 rounded-full border-4 border-transparent border-t-blue-400 animate-spin"></div>
                 <div
-                  className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full transition-all duration-500 ease-out relative overflow-hidden"
-                  style={{ width: `${Math.min(loadingProgress, 100)}%` }}
-                >
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent animate-pulse"></div>
-                </div>
+                  className="absolute inset-4 rounded-full border-4 border-transparent border-r-purple-400 animate-spin"
+                  style={{
+                    animationDirection: "reverse",
+                    animationDuration: "2s",
+                  }}
+                ></div>
+                <div
+                  className="absolute inset-6 rounded-full border-4 border-transparent border-b-cyan-400 animate-spin"
+                  style={{ animationDuration: "3s" }}
+                ></div>
+
+                {/* Center Glow */}
+                <div className="absolute inset-8 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full blur-lg opacity-60 electric-pulse"></div>
               </div>
-              <div className="flex justify-between items-center mt-3">
-                <span className="text-sm font-medium text-gray-600 font-body">
-                  Loading...
-                </span>
-                <span className="text-sm font-bold text-blue-600 font-body">
-                  {Math.round(loadingProgress)}%
-                </span>
+
+              {/* Enhanced Progress System */}
+              <div className="w-full max-w-md mx-auto space-y-4">
+                {/* Progress Track */}
+                <div className="relative h-3 bg-slate-800/50 rounded-full overflow-hidden backdrop-blur-sm border border-blue-500/20">
+                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-blue-400/20 to-transparent electric-shimmer"></div>
+                  <div
+                    className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-cyan-500 rounded-full transition-all duration-700 ease-out relative overflow-hidden"
+                    style={{ width: `${Math.min(loadingProgress, 100)}%` }}
+                  >
+                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse"></div>
+                    <div className="absolute inset-0 electric-shimmer"></div>
+                  </div>
+                </div>
+
+                {/* Progress Info */}
+                <div className="flex justify-between items-center">
+                  <span className="text-sm font-medium text-blue-300 font-body">
+                    {loadingProgress < 25
+                      ? "🚀 Initializing Platform..."
+                      : loadingProgress < 50
+                        ? "⚡ Loading Game Engine..."
+                        : loadingProgress < 75
+                          ? "🎮 Preparing Interface..."
+                          : loadingProgress < 95
+                            ? "🎯 Finalizing Setup..."
+                            : "✨ Almost Ready..."}
+                  </span>
+                  <span className="text-lg font-black text-white font-heading">
+                    {Math.round(loadingProgress)}%
+                  </span>
+                </div>
               </div>
             </div>
 
-            {/* Loading Status */}
-            <div className="space-y-2">
-              <p className="text-base sm:text-lg font-medium text-gray-700 font-body">
-                {loadingProgress < 30
-                  ? "Initializing Platform..."
-                  : loadingProgress < 60
-                    ? "Loading Game Engine..."
-                    : loadingProgress < 90
-                      ? "Preparing Interface..."
-                      : "Almost Ready..."}
-              </p>
-              <p className="text-sm text-gray-500 font-body">
-                Welcome to the modern gaming experience
-              </p>
+            {/* Interactive Feature Cards */}
+            <div className="grid grid-cols-3 gap-4 sm:gap-6 mt-12">
+              {[
+                { icon: "🔒", title: "Secure", desc: "End-to-end encryption" },
+                { icon: "👥", title: "Multiplayer", desc: "Real-time battles" },
+                { icon: "⚡", title: "Lightning", desc: "Ultra-fast gaming" },
+              ].map((feature, index) => (
+                <div key={index} className="relative group tap-target">
+                  <div className="absolute -inset-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 rounded-xl blur opacity-0 group-hover:opacity-100 transition-all duration-500"></div>
+                  <div className="relative electric-glass backdrop-blur-xl p-4 sm:p-6 rounded-xl border border-blue-300/20 hover:border-blue-300/40 transition-all duration-300">
+                    <div className="text-2xl sm:text-3xl mb-2">
+                      {feature.icon}
+                    </div>
+                    <h3 className="text-xs sm:text-sm font-bold text-white font-heading">
+                      {feature.title}
+                    </h3>
+                    <p className="text-xs text-blue-200 font-body mt-1">
+                      {feature.desc}
+                    </p>
+                  </div>
+                </div>
+              ))}
             </div>
 
-            {/* Modern Features */}
-            <div className="grid grid-cols-3 gap-4 mt-8">
-              <div className="text-center tap-target">
-                <div className="w-10 h-10 mx-auto mb-2 bg-gradient-to-br from-blue-100 to-blue-200 rounded-lg flex items-center justify-center">
-                  <svg
-                    className="w-5 h-5 text-blue-600"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                </div>
-                <p className="text-xs font-medium text-gray-600 font-body">
-                  Secure
-                </p>
-              </div>
-              <div className="text-center tap-target">
-                <div className="w-10 h-10 mx-auto mb-2 bg-gradient-to-br from-blue-100 to-blue-200 rounded-lg flex items-center justify-center">
-                  <svg
-                    className="w-5 h-5 text-blue-600"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z" />
-                  </svg>
-                </div>
-                <p className="text-xs font-medium text-gray-600 font-body">
-                  Multiplayer
-                </p>
-              </div>
-              <div className="text-center tap-target">
-                <div className="w-10 h-10 mx-auto mb-2 bg-gradient-to-br from-blue-100 to-blue-200 rounded-lg flex items-center justify-center">
-                  <svg
-                    className="w-5 h-5 text-blue-600"
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z" />
-                  </svg>
-                </div>
-                <p className="text-xs font-medium text-gray-600 font-body">
-                  Real-time
+            {/* Status Message */}
+            <div className="relative">
+              <div className="electric-glass backdrop-blur-xl rounded-2xl p-4 border border-blue-300/20">
+                <p className="text-blue-100 font-body text-sm sm:text-base">
+                  🌟 Welcome to the next generation gaming experience
                 </p>
               </div>
             </div>
           </div>
         </div>
 
-        {/* Bottom Branding */}
-        <div className="absolute bottom-8 left-0 right-0 text-center">
-          <p className="text-sm text-gray-500 font-medium font-body">
-            © 2024 NNC Games • Modern Gaming Platform
-          </p>
+        {/* Enhanced Footer */}
+        <div className="absolute bottom-6 left-0 right-0 text-center">
+          <div className="electric-glass backdrop-blur-xl inline-block px-6 py-2 rounded-full border border-blue-300/20">
+            <p className="text-xs sm:text-sm text-blue-200 font-medium font-body">
+              © 2024 NNC Games • Professional Gaming Platform
+            </p>
+          </div>
         </div>
       </div>
     );

--- a/src/components/chess/ChessBoard.tsx
+++ b/src/components/chess/ChessBoard.tsx
@@ -280,10 +280,10 @@ export const ChessBoard: React.FC<ChessBoardProps> = ({
 
   return (
     <div className="flex flex-col items-center w-full px-1 sm:px-2">
-      <div className="lavender-card p-2 sm:p-4 md:p-6 lg:p-8 rounded-lg sm:rounded-xl lavender-shadow-lg w-full h-full max-w-none sm:max-w-4xl md:max-w-5xl lg:max-w-6xl xl:max-w-7xl border-2 sm:border-4 border-purple-300">
+      <div className="electric-card p-2 sm:p-4 md:p-6 lg:p-8 rounded-lg sm:rounded-xl electric-shadow-lg w-full h-full max-w-none sm:max-w-4xl md:max-w-5xl lg:max-w-6xl xl:max-w-7xl border-2 sm:border-4 electric-border">
         <div
           ref={boardRef}
-          className="grid grid-cols-8 gap-0 aspect-square w-full h-full border-2 sm:border-4 border-purple-400 rounded-md sm:rounded-lg overflow-hidden lavender-shadow-lg"
+          className="grid grid-cols-8 gap-0 aspect-square w-full h-full border-2 sm:border-4 border-blue-400 rounded-md sm:rounded-lg overflow-hidden electric-shadow-lg"
         >
           {Array.from({ length: 8 }, (_, rowIndex) =>
             Array.from({ length: 8 }, (_, colIndex) => {

--- a/src/components/chess/ChessBoard.tsx
+++ b/src/components/chess/ChessBoard.tsx
@@ -352,16 +352,16 @@ export const ChessBoard: React.FC<ChessBoardProps> = ({
         </div>
 
         <div className="mt-2 sm:mt-4 md:mt-8 text-center">
-          <div className="lavender-text text-sm sm:text-lg md:text-2xl font-bold lavender-glass rounded-md sm:rounded-lg px-3 py-2 sm:px-6 sm:py-4 border border-purple-300 sm:border-2 lavender-shadow">
+          <div className="electric-text text-sm sm:text-lg md:text-2xl font-bold electric-glass rounded-md sm:rounded-lg px-3 py-2 sm:px-6 sm:py-4 border electric-border sm:border-2 electric-shadow tap-target">
             Playing as {playerColor === "white" ? "⚪ White" : "⚫ Black"}
           </div>
           {!isPlayerTurn && !disabled && (
-            <div className="text-purple-600 mt-2 sm:mt-3 text-sm sm:text-base md:text-lg font-bold lavender-glass rounded-md px-3 py-2 sm:px-4 sm:py-3 inline-block border border-purple-300 sm:border-2 lavender-shadow">
+            <div className="text-blue-600 mt-2 sm:mt-3 text-sm sm:text-base md:text-lg font-bold electric-glass rounded-md px-3 py-2 sm:px-4 sm:py-3 inline-block border electric-border sm:border-2 electric-shadow tap-target">
               Opponent's turn...
             </div>
           )}
           {disabled && (
-            <div className="text-gray-600 mt-2 sm:mt-3 text-sm sm:text-base md:text-lg font-bold lavender-glass rounded-md px-3 py-2 sm:px-4 sm:py-3 inline-block border border-gray-300 sm:border-2 lavender-shadow">
+            <div className="text-gray-600 mt-2 sm:mt-3 text-sm sm:text-base md:text-lg font-bold electric-glass rounded-md px-3 py-2 sm:px-4 sm:py-3 inline-block border border-gray-300 sm:border-2 electric-shadow tap-target">
               Spectating
             </div>
           )}

--- a/src/components/chess/ChessBoard.tsx
+++ b/src/components/chess/ChessBoard.tsx
@@ -304,22 +304,22 @@ export const ChessBoard: React.FC<ChessBoardProps> = ({
                     transition-colors duration-200 active:scale-95 relative overflow-hidden
                     ${
                       isLightSquare(rowIndex, colIndex)
-                        ? "bg-lavender-50 hover:bg-lavender-100"
-                        : "bg-purple-300 hover:bg-purple-400"
+                        ? "bg-electric-50 hover:bg-electric-100"
+                        : "bg-blue-300 hover:bg-blue-400"
                     }
                     ${
                       isSquareHighlighted(rowIndex, colIndex)
-                        ? "ring-4 ring-purple-400 bg-purple-200"
+                        ? "ring-4 ring-blue-400 bg-blue-200"
                         : ""
                     }
                     ${
                       isPossibleMove(rowIndex, colIndex)
-                        ? "after:absolute after:inset-1/3 after:bg-purple-500 after:rounded-full after:opacity-70"
+                        ? "after:absolute after:inset-1/3 after:bg-blue-500 after:rounded-full after:opacity-70"
                         : ""
                     }
                     ${
                       isLastMove(rowIndex, colIndex)
-                        ? "bg-lavender-300 ring-2 ring-purple-500"
+                        ? "bg-electric-300 ring-2 ring-blue-500"
                         : ""
                     }
                     ${disabled || !isPlayerTurn ? "cursor-default opacity-70" : "cursor-pointer"}

--- a/src/components/chess/PawnPromotionDialog.tsx
+++ b/src/components/chess/PawnPromotionDialog.tsx
@@ -59,16 +59,16 @@ export const PawnPromotionDialog = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={() => onCancel()}>
-      <DialogContent className="sm:max-w-md lavender-glass lavender-shadow border-purple-200/50">
+      <DialogContent className="sm:max-w-md electric-glass electric-shadow border-blue-200/50">
         <DialogHeader>
-          <DialogTitle className="text-center text-purple-600 flex items-center justify-center gap-2">
+          <DialogTitle className="text-center text-blue-600 flex items-center justify-center gap-2 font-heading">
             <Crown className="h-5 w-5" />
             Pawn Promotion
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <p className="text-center text-gray-600 text-sm">
+        <div className="space-y-4 clean-spacing">
+          <p className="text-center text-gray-600 text-sm font-body">
             Your pawn has reached the end! Choose which piece to promote it to:
           </p>
 
@@ -78,17 +78,17 @@ export const PawnPromotionDialog = ({
                 key={piece.type}
                 onClick={() => onSelect(piece.type)}
                 variant="outline"
-                className="h-auto p-4 flex flex-col items-center gap-2 hover:bg-purple-50 border-purple-200"
+                className="h-auto p-4 flex flex-col items-center gap-2 hover:bg-blue-50 border-blue-200 tap-target electric-shadow font-body min-h-[60px]"
               >
                 <div className="flex items-center gap-2">
                   <piece.icon className={`h-5 w-5 ${piece.color}`} />
                   <span className="text-2xl">{piece.symbol}</span>
                 </div>
                 <div className="text-center">
-                  <div className="font-semibold text-gray-800">
+                  <div className="font-semibold text-gray-800 font-heading">
                     {piece.name}
                   </div>
-                  <div className="text-xs text-gray-500">
+                  <div className="text-xs text-gray-500 font-body">
                     {piece.description}
                   </div>
                 </div>
@@ -97,7 +97,7 @@ export const PawnPromotionDialog = ({
           </div>
 
           <div className="text-center">
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 font-body">
               Most players choose Queen (most powerful)
             </p>
           </div>
@@ -105,7 +105,7 @@ export const PawnPromotionDialog = ({
           <Button
             onClick={onCancel}
             variant="ghost"
-            className="w-full text-gray-500 hover:text-gray-700"
+            className="w-full text-gray-500 hover:text-gray-700 tap-target font-body"
           >
             Cancel Move
           </Button>

--- a/src/components/chess/PawnPromotionDialog.tsx
+++ b/src/components/chess/PawnPromotionDialog.tsx
@@ -29,7 +29,7 @@ export const PawnPromotionDialog = ({
       icon: Crown,
       symbol: playerColor === "white" ? "♕" : "♛",
       description: "Most powerful piece",
-      color: "text-purple-600",
+      color: "text-blue-600",
     },
     {
       type: "r" as PieceType,
@@ -37,7 +37,7 @@ export const PawnPromotionDialog = ({
       icon: Castle,
       symbol: playerColor === "white" ? "♖" : "♜",
       description: "Moves horizontally/vertically",
-      color: "text-blue-600",
+      color: "text-blue-500",
     },
     {
       type: "b" as PieceType,
@@ -45,7 +45,7 @@ export const PawnPromotionDialog = ({
       icon: BishopIcon,
       symbol: playerColor === "white" ? "♗" : "♝",
       description: "Moves diagonally",
-      color: "text-green-600",
+      color: "text-blue-700",
     },
     {
       type: "n" as PieceType,
@@ -53,7 +53,7 @@ export const PawnPromotionDialog = ({
       icon: Swords,
       symbol: playerColor === "white" ? "♘" : "♞",
       description: "Moves in L-shape",
-      color: "text-orange-600",
+      color: "text-blue-800",
     },
   ];
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -90,12 +90,12 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
 
   return (
     <nav className="relative">
-      {/* Background with Lavender Glassmorphism */}
+      {/* Background with Electric Blue Glassmorphism */}
       <div
-        className={`absolute inset-0 ${isMobile ? "lavender-card" : "lavender-glass"} border-b border-purple-200/50`}
+        className={`absolute inset-0 ${isMobile ? "electric-card" : "electric-glass"} border-b border-blue-200/50`}
       >
         {!isMobile && (
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-100/10 via-lavender-100/10 to-indigo-100/10"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-100/10 via-electric-100/10 to-cyan-100/10"></div>
         )}
       </div>
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -213,9 +213,9 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
             {/* Mobile Menu Button */}
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="lg:hidden relative group text-white p-3 rounded-xl hover:bg-gray-800/50 transition-all duration-300 min-w-[48px] min-h-[48px] flex items-center justify-center"
+              className="lg:hidden relative group text-white p-3 rounded-xl hover:bg-blue-800/50 transition-all duration-300 tap-target flex items-center justify-center"
             >
-              <div className="absolute inset-0 bg-gradient-to-r from-gray-500/20 to-slate-500/20 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 to-electric-500/20 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
               {mobileMenuOpen ? (
                 <X className="relative h-6 w-6 transform rotate-90 group-hover:rotate-0 transition-transform duration-300" />
               ) : (

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -319,10 +319,12 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
                   {/* Mobile Sign Out */}
                   <button
                     onClick={handleSignOut}
-                    className="w-full flex items-center gap-4 px-4 py-4 text-red-400 hover:bg-red-500/10 active:bg-red-500/20 rounded-xl transition-all duration-300 min-h-[56px]"
+                    className="w-full flex items-center gap-4 px-4 py-4 text-red-400 hover:bg-red-500/10 active:bg-red-500/20 rounded-xl transition-all duration-300 tap-target font-body"
                   >
                     <LogOut className="h-6 w-6 flex-shrink-0" />
-                    <span className="font-bold text-lg">Sign Out</span>
+                    <span className="font-bold text-lg font-heading">
+                      Sign Out
+                    </span>
                     <div className="ml-auto text-xl">🚪</div>
                   </button>
                 </>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -104,21 +104,21 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
           {/* Enhanced Logo */}
           <div className="flex items-center gap-3 group">
             <div className="relative">
-              <div className="absolute -inset-2 bg-gradient-to-r from-purple-400 to-indigo-400 rounded-full blur-lg opacity-60 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div className="relative p-2 bg-gradient-to-r from-purple-500 to-indigo-500 rounded-full">
+              <div className="absolute -inset-2 bg-gradient-to-r from-blue-400 to-cyan-400 rounded-full blur-lg opacity-60 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="relative p-2 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-full">
                 <Crown className="h-7 w-7 md:h-8 md:w-8 text-white drop-shadow-lg" />
               </div>
             </div>
             <div>
-              <span className="text-xl md:text-2xl font-black lavender-text-gradient">
+              <span className="text-xl md:text-2xl font-black electric-text-gradient font-heading">
                 NNC GAMES
               </span>
               <div className="flex items-center gap-1 mt-0.5">
-                <Star className="h-3 w-3 text-purple-400" />
-                <span className="text-xs text-purple-600 font-medium">
+                <Star className="h-3 w-3 text-blue-400" />
+                <span className="text-xs text-blue-600 font-medium font-body">
                   Chess Arena
                 </span>
-                <Star className="h-3 w-3 text-purple-400" />
+                <Star className="h-3 w-3 text-blue-400" />
               </div>
             </div>
           </div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -296,18 +296,18 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
                   <div className="px-4 py-4 border-t border-gray-700/50 mt-4">
                     <div className="flex items-center gap-3 mb-3">
                       <div className="relative">
-                        <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full blur-sm opacity-60"></div>
-                        <div className="relative w-10 h-10 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full flex items-center justify-center text-xl">
+                        <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-electric-400 rounded-full blur-sm opacity-60"></div>
+                        <div className="relative w-10 h-10 bg-gradient-to-r from-blue-500 to-electric-500 rounded-full flex items-center justify-center text-xl">
                           👤
                         </div>
                       </div>
                       <div>
-                        <p className="text-white font-bold text-base flex items-center gap-2">
+                        <p className="text-white font-bold text-base flex items-center gap-2 font-heading">
                           {profile?.username || "Player"}
                           <Sparkles className="h-4 w-4 text-yellow-400" />
                         </p>
                         <div className="flex items-center gap-2">
-                          <span className="text-green-400 text-sm font-bold">
+                          <span className="text-green-400 text-sm font-bold font-body">
                             Balance: ₹{wallet?.balance?.toFixed(2) || "0.00"}
                           </span>
                           <Zap className="h-4 w-4 text-yellow-400" />

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -172,22 +172,22 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
               <div className="hidden lg:flex items-center gap-4">
                 {/* User Profile Card */}
                 <div className="relative group">
-                  <div className="absolute -inset-1 bg-gradient-to-r from-purple-500 to-cyan-500 rounded-xl blur-lg opacity-0 group-hover:opacity-60 transition-opacity duration-300"></div>
-                  <div className="relative bg-gradient-to-r from-slate-800/80 to-slate-900/80 backdrop-blur-sm border border-purple-500/30 rounded-xl p-3">
+                  <div className="absolute -inset-1 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-xl blur-lg opacity-0 group-hover:opacity-60 transition-opacity duration-300"></div>
+                  <div className="relative bg-gradient-to-r from-slate-800/80 to-slate-900/80 backdrop-blur-sm border border-blue-500/30 rounded-xl p-3 tap-target">
                     <div className="flex items-center gap-3">
                       <div className="relative">
-                        <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full blur-sm opacity-60"></div>
-                        <div className="relative w-8 h-8 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full flex items-center justify-center text-lg">
+                        <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-electric-400 rounded-full blur-sm opacity-60"></div>
+                        <div className="relative w-8 h-8 bg-gradient-to-r from-blue-500 to-electric-500 rounded-full flex items-center justify-center text-lg">
                           👤
                         </div>
                       </div>
                       <div className="text-right">
-                        <p className="text-white font-bold text-sm flex items-center gap-1">
+                        <p className="text-white font-bold text-sm flex items-center gap-1 font-heading">
                           {profile?.username || "Player"}
                           <Sparkles className="h-3 w-3 text-yellow-400" />
                         </p>
                         <div className="flex items-center gap-1">
-                          <span className="text-green-400 text-xs font-bold">
+                          <span className="text-green-400 text-xs font-bold font-body">
                             ₹{wallet?.balance?.toFixed(2) || "0.00"}
                           </span>
                           <Zap className="h-3 w-3 text-yellow-400" />

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -137,19 +137,19 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
               return (
                 <div key={item.id} className="relative group">
                   {isActive && (
-                    <div className="absolute -inset-1 bg-gradient-to-r from-blue-500 via-purple-500 to-cyan-500 rounded-xl blur-lg opacity-60 animate-pulse"></div>
+                    <div className="absolute -inset-1 bg-gradient-to-r from-blue-500 via-electric-500 to-cyan-500 rounded-xl blur-lg opacity-60 animate-pulse"></div>
                   )}
                   <button
                     onClick={() => onViewChange(item.id)}
-                    className={`relative flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-300 transform hover:scale-105 ${
+                    className={`relative flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-300 transform hover:scale-105 tap-target font-body ${
                       isActive
-                        ? "bg-gradient-to-r from-blue-500/20 to-purple-500/20 text-white border border-purple-400/50 shadow-lg"
+                        ? "bg-gradient-to-r from-blue-500/20 to-electric-500/20 text-white border border-blue-400/50 shadow-lg"
                         : "text-gray-300 hover:text-white hover:bg-gray-800/50 backdrop-blur-sm"
                     }`}
                   >
                     <div className="relative">
                       {isActive && (
-                        <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full blur-sm opacity-60"></div>
+                        <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-electric-400 rounded-full blur-sm opacity-60"></div>
                       )}
                       <Icon
                         className={`relative h-5 w-5 transition-all duration-300 ${isActive ? "text-white drop-shadow-lg" : ""}`}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -242,28 +242,30 @@ export const Navbar = ({ currentView, onViewChange }: NavbarProps) => {
                 return (
                   <div key={item.id} className="relative">
                     {isActive && (
-                      <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 via-purple-500 to-cyan-500 rounded-xl blur-lg opacity-60"></div>
+                      <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-500 via-electric-500 to-cyan-500 rounded-xl blur-lg opacity-60"></div>
                     )}
                     <button
                       onClick={() => {
                         onViewChange(item.id);
                         setMobileMenuOpen(false);
                       }}
-                      className={`relative w-full flex items-center gap-4 px-4 py-4 rounded-xl transition-all duration-300 text-left min-h-[56px] ${
+                      className={`relative w-full flex items-center gap-4 px-4 py-4 rounded-xl transition-all duration-300 text-left tap-target font-body ${
                         isActive
-                          ? "bg-gradient-to-r from-blue-500/20 to-purple-500/20 text-white border border-purple-400/50"
+                          ? "bg-gradient-to-r from-blue-500/20 to-electric-500/20 text-white border border-blue-400/50"
                           : "text-gray-300 hover:text-white hover:bg-gray-800/50 active:bg-gray-700/50"
                       }`}
                     >
                       <div className="relative">
                         {isActive && (
-                          <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full blur-sm opacity-60"></div>
+                          <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-electric-400 rounded-full blur-sm opacity-60"></div>
                         )}
                         <Icon
                           className={`relative h-6 w-6 flex-shrink-0 ${isActive ? "text-white drop-shadow-lg" : ""}`}
                         />
                       </div>
-                      <span className="font-bold text-lg">{item.label}</span>
+                      <span className="font-bold text-lg font-heading">
+                        {item.label}
+                      </span>
 
                       {isActive && (
                         <div className="ml-auto flex items-center gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -286,22 +286,66 @@
 @keyframes electricFloat {
   0%,
   100% {
-    transform: translateY(0px);
+    transform: translateY(0px) scale(1);
   }
-  50% {
-    transform: translateY(-10px);
+  33% {
+    transform: translateY(-15px) scale(1.05);
+  }
+  66% {
+    transform: translateY(-5px) scale(0.95);
   }
 }
 
 @keyframes electricPulse {
   0%,
   100% {
-    opacity: 0.8;
+    opacity: 0.6;
     transform: scale(1);
   }
   50% {
     opacity: 1;
-    transform: scale(1.05);
+    transform: scale(1.1);
+  }
+}
+
+@keyframes particleFloat {
+  0%,
+  100% {
+    transform: translateY(0px) translateX(0px);
+    opacity: 0.3;
+  }
+  25% {
+    transform: translateY(-20px) translateX(10px);
+    opacity: 0.8;
+  }
+  50% {
+    transform: translateY(-10px) translateX(-5px);
+    opacity: 1;
+  }
+  75% {
+    transform: translateY(-30px) translateX(15px);
+    opacity: 0.6;
+  }
+}
+
+@keyframes rotateGlow {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes meshGradient {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(1) rotate(0deg);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(1.1) rotate(180deg);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -350,11 +350,23 @@
 }
 
 .electric-float {
-  animation: electricFloat 3s ease-in-out infinite;
+  animation: electricFloat 4s ease-in-out infinite;
 }
 
 .electric-pulse {
-  animation: electricPulse 2s ease-in-out infinite;
+  animation: electricPulse 2.5s ease-in-out infinite;
+}
+
+.particle-float {
+  animation: particleFloat 6s ease-in-out infinite;
+}
+
+.rotate-glow {
+  animation: rotateGlow 10s linear infinite;
+}
+
+.mesh-gradient {
+  animation: meshGradient 8s ease-in-out infinite;
 }
 
 /* Professional loading animations */


### PR DESCRIPTION
Updates the visual theme across chess components and navigation from lavender/purple color scheme to electric blue.

Changes include:
- ChessBoard.tsx: Replace lavender-* classes with electric-* classes, change purple colors to blue variants
- PawnPromotionDialog.tsx: Update color scheme from purple to blue, add font classes and tap-target styling
- Navbar.tsx: Switch from lavender/purple gradients to electric blue theme, update glassmorphism effects

All functional behavior remains unchanged - this is purely a visual theme update.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6be031e6ee648428be10aeb45f6175f/glow-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6be031e6ee648428be10aeb45f6175f</projectId>-->
<!--<branchName>glow-zone</branchName>-->