### PR TITLE
Update UI theme from blue to vibrant multi-color palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,37 +44,51 @@ const App = () => {
       <div className="fixed inset-0 overflow-hidden font-body">
         {/* Advanced Multi-Layer Background System */}
         <div className="absolute inset-0">
-          {/* Primary Gradient Layer */}
-          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900"></div>
+          {/* Primary Vibrant Gradient Layer */}
+          <div className="absolute inset-0 bg-gradient-to-br from-purple-900 via-violet-800 to-fuchsia-900"></div>
 
-          {/* Dynamic Mesh Gradient */}
-          <div className="absolute inset-0 opacity-40">
+          {/* Dynamic Mesh Gradient with Vibrant Colors */}
+          <div className="absolute inset-0 opacity-50">
             <div
               className="h-full w-full"
               style={{
                 backgroundImage: `
-                  radial-gradient(circle at 20% 80%, hsl(205, 100%, 50%) 0%, transparent 50%),
-                  radial-gradient(circle at 80% 20%, hsl(195, 100%, 55%) 0%, transparent 50%),
-                  radial-gradient(circle at 40% 40%, hsl(215, 100%, 45%) 0%, transparent 40%),
-                  conic-gradient(from 180deg at 50% 50%, transparent 0deg, hsl(205, 100%, 50%) 180deg, transparent 360deg)
+                  radial-gradient(circle at 20% 80%, hsl(270, 95%, 60%) 0%, transparent 50%),
+                  radial-gradient(circle at 80% 20%, hsl(195, 100%, 50%) 0%, transparent 50%),
+                  radial-gradient(circle at 40% 40%, hsl(330, 85%, 65%) 0%, transparent 40%),
+                  radial-gradient(circle at 60% 80%, hsl(145, 85%, 45%) 0%, transparent 35%),
+                  conic-gradient(from 180deg at 50% 50%, transparent 0deg, hsl(270, 95%, 60%) 90deg, hsl(195, 100%, 50%) 180deg, hsl(330, 85%, 65%) 270deg, transparent 360deg)
                 `,
               }}
             ></div>
           </div>
 
-          {/* Animated Particle System */}
-          <div className="absolute inset-0 opacity-20">
-            {[...Array(50)].map((_, i) => (
-              <div
-                key={i}
-                className="absolute w-1 h-1 bg-blue-400 rounded-full"
-                style={{
-                  left: `${Math.random() * 100}%`,
-                  top: `${Math.random() * 100}%`,
-                  animationDelay: `${Math.random() * 3}s`,
-                }}
-              ></div>
-            ))}
+          {/* Animated Particle System with Vibrant Colors */}
+          <div className="absolute inset-0 opacity-30">
+            {[...Array(60)].map((_, i) => {
+              const colors = [
+                "bg-purple-400",
+                "bg-cyan-400",
+                "bg-pink-400",
+                "bg-green-400",
+                "bg-yellow-400",
+                "bg-orange-400",
+              ];
+              const randomColor =
+                colors[Math.floor(Math.random() * colors.length)];
+              return (
+                <div
+                  key={i}
+                  className={`absolute w-1.5 h-1.5 ${randomColor} rounded-full animate-pulse`}
+                  style={{
+                    left: `${Math.random() * 100}%`,
+                    top: `${Math.random() * 100}%`,
+                    animationDelay: `${Math.random() * 3}s`,
+                    boxShadow: `0 0 6px currentColor`,
+                  }}
+                ></div>
+              );
+            })}
           </div>
 
           {/* Geometric Pattern Overlay */}
@@ -103,18 +117,22 @@ const App = () => {
 
         {/* Floating Interactive Elements */}
         <div className="absolute inset-0 pointer-events-none">
-          {/* Floating Orbs */}
+          {/* Vibrant Floating Orbs */}
           <div
-            className="absolute top-1/4 left-1/4 w-20 h-20 bg-gradient-to-r from-blue-400/30 to-cyan-400/30 rounded-full blur-xl electric-float"
-            style={{ animationDelay: "0s" }}
+            className="absolute top-1/4 left-1/4 w-24 h-24 bg-gradient-to-r from-purple-500/40 to-pink-500/40 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "0s", filter: "brightness(1.2)" }}
           ></div>
           <div
-            className="absolute top-3/4 right-1/4 w-16 h-16 bg-gradient-to-r from-purple-400/30 to-blue-400/30 rounded-full blur-xl electric-float"
-            style={{ animationDelay: "1s" }}
+            className="absolute top-3/4 right-1/4 w-20 h-20 bg-gradient-to-r from-cyan-500/40 to-blue-500/40 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "1s", filter: "brightness(1.2)" }}
           ></div>
           <div
-            className="absolute top-1/2 left-3/4 w-12 h-12 bg-gradient-to-r from-cyan-400/30 to-blue-400/30 rounded-full blur-xl electric-float"
-            style={{ animationDelay: "2s" }}
+            className="absolute top-1/2 left-3/4 w-16 h-16 bg-gradient-to-r from-green-500/40 to-emerald-500/40 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "2s", filter: "brightness(1.2)" }}
+          ></div>
+          <div
+            className="absolute top-1/3 right-1/3 w-14 h-14 bg-gradient-to-r from-orange-500/40 to-yellow-500/40 rounded-full blur-xl electric-float"
+            style={{ animationDelay: "1.5s", filter: "brightness(1.2)" }}
           ></div>
         </div>
 
@@ -123,20 +141,23 @@ const App = () => {
           <div className="text-center space-y-10 sm:space-y-12 max-w-lg sm:max-w-xl mx-auto w-full">
             {/* Revolutionary Logo Design */}
             <div className="relative group">
-              {/* Outer Glow Ring */}
-              <div className="absolute -inset-8 bg-gradient-to-r from-blue-500/20 via-purple-500/20 to-cyan-500/20 rounded-full blur-2xl group-hover:blur-3xl transition-all duration-1000"></div>
+              {/* Outer Glow Ring - Enhanced Vibrancy */}
+              <div className="absolute -inset-10 bg-gradient-to-r from-purple-500/30 via-pink-500/30 via-cyan-500/30 to-green-500/30 rounded-full blur-3xl group-hover:blur-4xl transition-all duration-1000"></div>
 
               {/* Logo Container */}
               <div className="relative">
-                <div className="electric-glass backdrop-blur-2xl rounded-full p-8 sm:p-12 border border-blue-300/30">
-                  {/* Rotating Border */}
-                  <div className="absolute inset-0 rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-cyan-500 opacity-75 blur-sm"></div>
-                  <div className="absolute inset-0.5 rounded-full bg-slate-900/80 backdrop-blur-xl"></div>
+                <div className="electric-glass backdrop-blur-2xl rounded-full p-8 sm:p-12 border border-purple-300/40">
+                  {/* Rotating Border - More Vibrant */}
+                  <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-500 via-pink-500 via-cyan-500 to-green-500 opacity-85 blur-sm"></div>
+                  <div className="absolute inset-0.5 rounded-full bg-slate-900/85 backdrop-blur-xl"></div>
 
-                  {/* Logo Icon */}
+                  {/* Logo Icon - Enhanced with Vibrant Colors */}
                   <div className="relative w-20 h-20 sm:w-24 sm:h-24 mx-auto">
-                    <div className="absolute inset-0 bg-gradient-to-br from-blue-400 via-purple-500 to-cyan-400 rounded-3xl electric-pulse transform rotate-45"></div>
-                    <div className="absolute inset-3 bg-gradient-to-br from-white to-blue-50 rounded-2xl flex items-center justify-center transform -rotate-45">
+                    <div
+                      className="absolute inset-0 bg-gradient-to-br from-purple-400 via-pink-500 via-cyan-400 to-green-400 rounded-3xl electric-pulse transform rotate-45"
+                      style={{ filter: "brightness(1.1)" }}
+                    ></div>
+                    <div className="absolute inset-3 bg-gradient-to-br from-white to-purple-50 rounded-2xl flex items-center justify-center transform -rotate-45">
                       <svg
                         className="w-10 h-10 sm:w-12 sm:h-12 text-blue-600"
                         fill="currentColor"
@@ -154,23 +175,32 @@ const App = () => {
 
             {/* Advanced Typography System */}
             <div className="space-y-6">
-              {/* Main Title */}
+              {/* Main Title - Ultra Vibrant */}
               <div className="relative">
                 <h1 className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black font-heading leading-none">
-                  <span className="block bg-gradient-to-r from-blue-200 via-white to-cyan-200 bg-clip-text text-transparent drop-shadow-2xl">
+                  <span
+                    className="block bg-gradient-to-r from-purple-200 via-pink-100 via-white to-cyan-200 bg-clip-text text-transparent drop-shadow-2xl"
+                    style={{ filter: "brightness(1.2)" }}
+                  >
                     GAME
                   </span>
-                  <span className="block bg-gradient-to-r from-cyan-300 via-blue-300 to-purple-300 bg-clip-text text-transparent electric-text-gradient">
+                  <span
+                    className="block bg-gradient-to-r from-cyan-300 via-purple-300 via-pink-300 to-green-300 bg-clip-text text-transparent electric-text-gradient"
+                    style={{ filter: "brightness(1.1)" }}
+                  >
                     HUB
                   </span>
                 </h1>
 
                 {/* Subtitle with Enhanced Styling */}
                 <div className="mt-4 relative">
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-blue-500/20 to-transparent blur-xl"></div>
-                  <p className="relative text-xl sm:text-2xl md:text-3xl font-medium text-blue-200 font-body tracking-widest">
+                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-purple-500/25 via-pink-500/20 to-transparent blur-xl"></div>
+                  <p className="relative text-xl sm:text-2xl md:text-3xl font-medium text-purple-200 font-body tracking-widest">
                     BY
-                    <span className="mx-3 font-black text-white electric-text-gradient">
+                    <span
+                      className="mx-3 font-black bg-gradient-to-r from-white via-purple-200 to-cyan-200 bg-clip-text text-transparent"
+                      style={{ filter: "brightness(1.15)" }}
+                    >
                       NNC GAMES
                     </span>
                   </p>
@@ -180,37 +210,51 @@ const App = () => {
 
             {/* Sophisticated Loading Animation */}
             <div className="relative space-y-8">
-              {/* Multi-Ring Spinner */}
+              {/* Multi-Ring Spinner - Ultra Vibrant */}
               <div className="relative w-24 h-24 sm:w-28 sm:h-28 mx-auto">
-                <div className="absolute inset-0 rounded-full border-4 border-blue-500/30"></div>
-                <div className="absolute inset-2 rounded-full border-4 border-transparent border-t-blue-400 animate-spin"></div>
+                <div className="absolute inset-0 rounded-full border-4 border-purple-500/40"></div>
                 <div
-                  className="absolute inset-4 rounded-full border-4 border-transparent border-r-purple-400 animate-spin"
+                  className="absolute inset-2 rounded-full border-4 border-transparent border-t-purple-400 animate-spin"
+                  style={{ filter: "brightness(1.2)" }}
+                ></div>
+                <div
+                  className="absolute inset-4 rounded-full border-4 border-transparent border-r-pink-400 animate-spin"
                   style={{
                     animationDirection: "reverse",
                     animationDuration: "2s",
+                    filter: "brightness(1.2)",
                   }}
                 ></div>
                 <div
                   className="absolute inset-6 rounded-full border-4 border-transparent border-b-cyan-400 animate-spin"
-                  style={{ animationDuration: "3s" }}
+                  style={{ animationDuration: "3s", filter: "brightness(1.2)" }}
                 ></div>
 
-                {/* Center Glow */}
-                <div className="absolute inset-8 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full blur-lg opacity-60 electric-pulse"></div>
+                {/* Center Glow - Enhanced */}
+                <div
+                  className="absolute inset-8 bg-gradient-to-r from-purple-500 via-pink-500 to-cyan-500 rounded-full blur-lg opacity-70 electric-pulse"
+                  style={{ filter: "brightness(1.1)" }}
+                ></div>
               </div>
 
               {/* Enhanced Progress System */}
               <div className="w-full max-w-md mx-auto space-y-4">
-                {/* Progress Track */}
-                <div className="relative h-3 bg-slate-800/50 rounded-full overflow-hidden backdrop-blur-sm border border-blue-500/20">
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-blue-400/20 to-transparent electric-shimmer"></div>
+                {/* Progress Track - Vibrant */}
+                <div className="relative h-4 bg-slate-800/60 rounded-full overflow-hidden backdrop-blur-sm border border-purple-500/30">
+                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-purple-400/25 via-pink-400/20 to-transparent electric-shimmer"></div>
                   <div
-                    className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-cyan-500 rounded-full transition-all duration-700 ease-out relative overflow-hidden"
-                    style={{ width: `${Math.min(loadingProgress, 100)}%` }}
+                    className="h-full bg-gradient-to-r from-purple-500 via-pink-500 via-cyan-500 to-green-500 rounded-full transition-all duration-700 ease-out relative overflow-hidden"
+                    style={{
+                      width: `${Math.min(loadingProgress, 100)}%`,
+                      filter: "brightness(1.1)",
+                    }}
                   >
-                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse"></div>
+                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/50 to-transparent animate-pulse"></div>
                     <div className="absolute inset-0 electric-shimmer"></div>
+                    <div
+                      className="absolute inset-0 bg-gradient-to-r from-transparent via-yellow-300/30 to-transparent"
+                      style={{ animation: "shimmer 1s ease-in-out infinite" }}
+                    ></div>
                   </div>
                 </div>
 
@@ -234,23 +278,49 @@ const App = () => {
               </div>
             </div>
 
-            {/* Interactive Feature Cards */}
+            {/* Interactive Feature Cards - Enhanced Vibrancy */}
             <div className="grid grid-cols-3 gap-4 sm:gap-6 mt-12">
               {[
-                { icon: "🔒", title: "Secure", desc: "End-to-end encryption" },
-                { icon: "👥", title: "Multiplayer", desc: "Real-time battles" },
-                { icon: "⚡", title: "Lightning", desc: "Ultra-fast gaming" },
+                {
+                  icon: "🔒",
+                  title: "Secure",
+                  desc: "End-to-end encryption",
+                  gradient: "from-purple-500/25 to-pink-500/25",
+                },
+                {
+                  icon: "👥",
+                  title: "Multiplayer",
+                  desc: "Real-time battles",
+                  gradient: "from-cyan-500/25 to-blue-500/25",
+                },
+                {
+                  icon: "⚡",
+                  title: "Lightning",
+                  desc: "Ultra-fast gaming",
+                  gradient: "from-green-500/25 to-emerald-500/25",
+                },
               ].map((feature, index) => (
                 <div key={index} className="relative group tap-target">
-                  <div className="absolute -inset-1 bg-gradient-to-r from-blue-500/20 to-purple-500/20 rounded-xl blur opacity-0 group-hover:opacity-100 transition-all duration-500"></div>
-                  <div className="relative electric-glass backdrop-blur-xl p-4 sm:p-6 rounded-xl border border-blue-300/20 hover:border-blue-300/40 transition-all duration-300">
-                    <div className="text-2xl sm:text-3xl mb-2">
+                  <div
+                    className={`absolute -inset-1 bg-gradient-to-r ${feature.gradient} rounded-xl blur opacity-0 group-hover:opacity-100 transition-all duration-500`}
+                  ></div>
+                  <div
+                    className="relative electric-glass backdrop-blur-xl p-4 sm:p-6 rounded-xl border border-purple-300/25 hover:border-purple-300/50 transition-all duration-300"
+                    style={{ background: "rgba(139, 69, 193, 0.1)" }}
+                  >
+                    <div className="text-2xl sm:text-3xl mb-2 filter brightness-110">
                       {feature.icon}
                     </div>
-                    <h3 className="text-xs sm:text-sm font-bold text-white font-heading">
+                    <h3
+                      className="text-xs sm:text-sm font-bold text-white font-heading"
+                      style={{ textShadow: "0 0 8px rgba(255, 255, 255, 0.3)" }}
+                    >
                       {feature.title}
                     </h3>
-                    <p className="text-xs text-blue-200 font-body mt-1">
+                    <p
+                      className="text-xs text-purple-200 font-body mt-1"
+                      style={{ textShadow: "0 0 4px rgba(196, 181, 253, 0.5)" }}
+                    >
                       {feature.desc}
                     </p>
                   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,87 +6,100 @@
 
 @layer base {
   :root {
-    /* Electric Blue Theme Variables */
+    /* Vibrant Theme Variables - Bright and Energetic */
     --background: 0 0% 100%;
-    --foreground: 222 84% 5%;
+    --foreground: 240 10% 4%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222 84% 5%;
+    --card-foreground: 240 10% 4%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222 84% 5%;
+    --popover-foreground: 240 10% 4%;
 
-    --primary: 205 100% 50%;
+    --primary: 270 95% 60%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 210 40% 98%;
-    --secondary-foreground: 222 47% 11%;
+    --secondary: 280 100% 95%;
+    --secondary-foreground: 240 10% 4%;
 
-    --muted: 210 40% 98%;
-    --muted-foreground: 215 15% 45%;
+    --muted: 280 100% 97%;
+    --muted-foreground: 240 5% 35%;
 
-    --accent: 205 95% 55%;
+    --accent: 195 100% 50%;
     --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 84% 60%;
+    --destructive: 0 90% 60%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 205 100% 50%;
+    --border: 280 50% 85%;
+    --input: 280 50% 90%;
+    --ring: 270 95% 60%;
 
-    --radius: 0.75rem;
+    --radius: 1rem;
 
-    /* Electric Blue specific colors */
-    --electric-50: 205 100% 98%;
-    --electric-100: 205 100% 95%;
-    --electric-200: 205 95% 88%;
-    --electric-300: 205 90% 78%;
-    --electric-400: 205 85% 65%;
-    --electric-500: 205 100% 50%;
-    --electric-600: 205 100% 45%;
-    --electric-700: 205 100% 38%;
-    --electric-800: 205 100% 30%;
-    --electric-900: 205 100% 22%;
+    /* Vibrant Color Palette */
+    --vibrant-purple: 270 95% 60%;
+    --vibrant-blue: 220 100% 55%;
+    --vibrant-cyan: 195 100% 50%;
+    --vibrant-green: 145 85% 45%;
+    --vibrant-orange: 30 100% 55%;
+    --vibrant-pink: 330 85% 65%;
+    --vibrant-yellow: 50 100% 60%;
 
-    /* Complementary colors */
-    --electric-accent: 195 100% 55%;
-    --electric-soft: 200 80% 85%;
-    --electric-muted: 210 30% 88%;
-    --electric-text: 222 84% 5%;
+    /* Electric/Neon variations */
+    --electric-50: 270 100% 98%;
+    --electric-100: 270 100% 95%;
+    --electric-200: 270 95% 88%;
+    --electric-300: 270 90% 78%;
+    --electric-400: 270 85% 68%;
+    --electric-500: 270 95% 60%;
+    --electric-600: 270 95% 52%;
+    --electric-700: 270 95% 42%;
+    --electric-800: 270 95% 32%;
+    --electric-900: 270 95% 22%;
+
+    /* Complementary vibrant colors */
+    --electric-accent: 195 100% 50%;
+    --electric-soft: 280 80% 92%;
+    --electric-muted: 280 50% 90%;
+    --electric-text: 240 10% 4%;
     --electric-light: 0 0% 100%;
-    --electric-neutral: 220 13% 91%;
+    --electric-neutral: 280 30% 88%;
   }
 
   .dark {
-    /* Dark electric blue theme */
-    --background: 222 84% 5%;
+    /* Dark vibrant theme with neon accents */
+    --background: 240 15% 6%;
     --foreground: 0 0% 98%;
 
-    --card: 222 84% 8%;
+    --card: 240 15% 8%;
     --card-foreground: 0 0% 98%;
 
-    --popover: 222 84% 5%;
+    --popover: 240 15% 6%;
     --popover-foreground: 0 0% 98%;
 
-    --primary: 205 100% 55%;
-    --primary-foreground: 222 84% 5%;
+    --primary: 270 95% 65%;
+    --primary-foreground: 240 15% 6%;
 
-    --secondary: 217 33% 17%;
+    --secondary: 240 20% 15%;
     --secondary-foreground: 0 0% 98%;
 
-    --muted: 217 33% 17%;
-    --muted-foreground: 215 20% 65%;
+    --muted: 240 20% 15%;
+    --muted-foreground: 240 5% 70%;
 
-    --accent: 205 95% 60%;
-    --accent-foreground: 222 84% 5%;
+    --accent: 195 100% 55%;
+    --accent-foreground: 240 15% 6%;
 
-    --destructive: 0 84% 60%;
+    --destructive: 0 90% 65%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 217 33% 17%;
-    --input: 217 33% 17%;
-    --ring: 205 100% 55%;
+    --border: 240 20% 18%;
+    --input: 240 20% 15%;
+    --ring: 270 95% 65%;
+
+    /* Enhanced vibrant colors for dark mode */
+    --electric-500: 270 95% 65%;
+    --electric-accent: 195 100% 55%;
   }
 }
 
@@ -143,14 +156,15 @@
   }
 }
 
-/* Electric Blue themed custom classes */
+/* Vibrant Electric themed custom classes */
 .electric-gradient {
   background: linear-gradient(
     135deg,
     hsl(var(--electric-100)) 0%,
-    hsl(var(--electric-200)) 25%,
-    hsl(var(--electric-300)) 50%,
-    hsl(var(--electric-200)) 75%,
+    hsl(var(--vibrant-purple)) 15%,
+    hsl(var(--vibrant-blue)) 35%,
+    hsl(var(--vibrant-cyan)) 65%,
+    hsl(var(--electric-200)) 85%,
     hsl(var(--electric-100)) 100%
   );
 }
@@ -159,17 +173,17 @@
   background: linear-gradient(
     135deg,
     hsl(var(--electric-800)) 0%,
-    hsl(var(--electric-700)) 25%,
-    hsl(var(--electric-600)) 50%,
-    hsl(var(--electric-700)) 75%,
+    hsl(var(--vibrant-purple)) 25%,
+    hsl(var(--vibrant-blue)) 50%,
+    hsl(var(--vibrant-cyan)) 75%,
     hsl(var(--electric-800)) 100%
   );
 }
 
 .electric-glass {
-  background: rgba(0, 150, 255, 0.1);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba(0, 150, 255, 0.2);
+  background: rgba(139, 69, 193, 0.15);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(139, 69, 193, 0.25);
 }
 
 .electric-shadow {
@@ -188,37 +202,44 @@
 .electric-text-gradient {
   background: linear-gradient(
     135deg,
-    hsl(var(--electric-600)) 0%,
-    hsl(var(--electric-accent)) 50%,
-    hsl(var(--electric-500)) 100%
+    hsl(var(--vibrant-purple)) 0%,
+    hsl(var(--vibrant-pink)) 25%,
+    hsl(var(--vibrant-cyan)) 50%,
+    hsl(var(--vibrant-blue)) 75%,
+    hsl(var(--vibrant-purple)) 100%
   );
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-size: 200% 200%;
   animation: gradientShift 3s ease-in-out infinite;
+  filter: brightness(1.1);
 }
 
 .electric-button {
   background: linear-gradient(
     135deg,
-    hsl(var(--electric-500)) 0%,
-    hsl(var(--electric-600)) 100%
+    hsl(var(--vibrant-purple)) 0%,
+    hsl(var(--vibrant-pink)) 50%,
+    hsl(var(--vibrant-cyan)) 100%
   );
   color: white;
-  border: 1px solid hsl(var(--electric-400));
+  border: 1px solid hsl(var(--vibrant-purple));
   transition: all 0.3s ease;
-  font-weight: 500;
+  font-weight: 600;
+  box-shadow: 0 4px 20px rgba(139, 69, 193, 0.3);
 }
 
 .electric-button:hover {
   background: linear-gradient(
     135deg,
-    hsl(var(--electric-600)) 0%,
-    hsl(var(--electric-700)) 100%
+    hsl(var(--vibrant-pink)) 0%,
+    hsl(var(--vibrant-purple)) 50%,
+    hsl(var(--vibrant-blue)) 100%
   );
-  transform: translateY(-1px);
-  box-shadow: 0 4px 15px rgba(0, 150, 255, 0.3);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(139, 69, 193, 0.4);
+  filter: brightness(1.1);
 }
 
 .electric-border {
@@ -464,19 +485,50 @@
   @apply electric-input;
 }
 
-/* Large tap targets for mobile */
+/* Enhanced mobile-friendly tap targets */
 .tap-target {
-  min-height: 44px;
-  min-width: 44px;
+  min-height: 48px;
+  min-width: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
+  touch-action: manipulation;
+  cursor: pointer;
 }
 
-/* High contrast text for accessibility */
+/* High contrast text for mobile accessibility */
 .high-contrast {
   color: hsl(var(--electric-text));
-  font-weight: 500;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+/* Mobile-optimized text sizes */
+.mobile-text-lg {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+}
+
+.mobile-text-xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 700;
+}
+
+/* Enhanced vibrant shadows */
+.vibrant-shadow {
+  box-shadow:
+    0 4px 20px rgba(139, 69, 193, 0.15),
+    0 8px 40px rgba(59, 130, 246, 0.1),
+    0 12px 60px rgba(236, 72, 153, 0.05);
+}
+
+.vibrant-shadow-lg {
+  box-shadow:
+    0 8px 30px rgba(139, 69, 193, 0.2),
+    0 12px 50px rgba(59, 130, 246, 0.15),
+    0 16px 80px rgba(236, 72, 153, 0.1);
 }
 
 /* Clean spacing utilities */
@@ -492,15 +544,49 @@
   margin-top: 1.5rem;
 }
 
-/* Responsive design helpers */
+/* Enhanced responsive design helpers */
 @media (max-width: 768px) {
   .electric-card {
-    border-radius: 8px;
-    margin: 4px;
+    border-radius: 12px;
+    margin: 6px;
+    padding: 1.25rem;
   }
 
   .tap-target {
+    min-height: 52px;
+    min-width: 52px;
+  }
+
+  /* Better mobile text contrast */
+  body {
+    font-size: 16px;
+    line-height: 1.6;
+  }
+
+  h1,
+  h2,
+  h3 {
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  /* Improved button sizing for mobile */
+  .electric-button {
     min-height: 48px;
-    min-width: 48px;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+}
+
+@media (max-width: 480px) {
+  .tap-target {
+    min-height: 56px;
+    min-width: 56px;
+  }
+
+  .electric-button {
+    min-height: 52px;
+    padding: 0.875rem 2rem;
+    font-size: 1.1rem;
   }
 }


### PR DESCRIPTION
This pull request updates the application's visual theme from a blue-based color scheme to a vibrant multi-color palette featuring purple, pink, cyan, green, orange, and yellow accents.

**Changes in App.tsx:**
- Updated primary gradient from slate/blue/indigo to purple/violet/fuchsia
- Enhanced mesh gradient with additional vibrant colors (purple, cyan, pink, green)
- Increased particle count from 50 to 60 with randomized vibrant colors
- Added glow effects and brightness filters to particles
- Updated floating orbs with new color combinations and increased sizes
- Enhanced logo styling with multi-color gradients and improved brightness
- Updated typography gradients to include purple, pink, cyan, and green
- Modified feature cards with purple-tinted backgrounds and enhanced text shadows
- Added fourth floating orb with orange/yellow gradient

**Changes in index.css:**
- Updated CSS custom properties from blue theme to vibrant purple-based theme
- Added new vibrant color variables for purple, blue, cyan, green, orange, pink, yellow
- Enhanced electric color palette with brighter, more saturated values
- Updated glass effect styling with purple tints and increased blur
- Improved text gradient animations with multi-color transitions
- Enhanced button styling with vibrant gradients and stronger shadows
- Added new vibrant shadow utilities with multi-color effects
- Improved mobile responsiveness with larger tap targets and better contrast
- Enhanced accessibility with stronger text shadows and improved font weights

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/61986b20154749fda2951408a05631ec/zenith-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>61986b20154749fda2951408a05631ec</projectId>-->
<!--<branchName>zenith-nest</branchName>-->