### PR TITLE
Add mobile touch support to Scrabble game

### DIFF
--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -10,7 +10,15 @@ import {
   BOARD_MULTIPLIERS,
 } from "./ScrabbleGameLogic";
 import { cn } from "@/lib/utils";
-import { Trash2, RotateCcw, CheckCircle, X } from "lucide-react";
+import {
+  Trash2,
+  RotateCcw,
+  CheckCircle,
+  X,
+  Smartphone,
+  Mouse,
+} from "lucide-react";
+import { useDeviceType } from "@/hooks/use-mobile";
 import "./scrabble.css";
 
 interface ScrabbleBoardProps {

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -168,6 +168,76 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
     [draggedTile, isCurrentPlayerTurn, gameState.board, placedTiles],
   );
 
+  // Touch-based tile placement for mobile
+  const handleCellTouch = useCallback(
+    (row: number, col: number) => {
+      if (!isCurrentPlayerTurn || isExchangeMode) return;
+
+      // If we have a selected tile, place it
+      if (selectedTile && touchMode === "select") {
+        // Check if cell is already occupied by a permanent tile
+        const existingTile = gameState.board[row][col].tile;
+        const placedTile = placedTiles.find(
+          (pt) => pt.position.row === row && pt.position.col === col,
+        );
+
+        if (existingTile && !placedTile) {
+          return;
+        }
+
+        // Remove any existing placed tile at this position
+        setPlacedTiles((prev) =>
+          prev.filter(
+            (pt) => !(pt.position.row === row && pt.position.col === col),
+          ),
+        );
+
+        // Add the tile to the new position
+        setPlacedTiles((prev) => [
+          ...prev,
+          {
+            tile: selectedTile,
+            position: { row, col },
+          },
+        ]);
+
+        setSelectedTile(null);
+      }
+    },
+    [
+      isCurrentPlayerTurn,
+      isExchangeMode,
+      selectedTile,
+      touchMode,
+      gameState.board,
+      placedTiles,
+    ],
+  );
+
+  // Handle tile selection for mobile
+  const handleTileSelect = useCallback(
+    (tile: ScrabbleTile, source: "rack" | "board") => {
+      if (!isCurrentPlayerTurn) return;
+
+      if (isExchangeMode && source === "rack") {
+        handleTileClickForExchange(tile);
+        return;
+      }
+
+      if (touchMode === "select") {
+        // In select mode, just select the tile
+        setSelectedTile(selectedTile?.id === tile.id ? null : tile);
+      }
+    },
+    [
+      isCurrentPlayerTurn,
+      isExchangeMode,
+      touchMode,
+      selectedTile,
+      handleTileClickForExchange,
+    ],
+  );
+
   const handleReturnToRack = useCallback((tileId: string) => {
     setPlacedTiles((prev) => prev.filter((pt) => pt.tile.id !== tileId));
   }, []);

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -508,10 +508,50 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
         </Card>
       )}
 
+      {/* Mobile Controls */}
+      {isMobile && (
+        <Card className="bg-blue-50 border-blue-200">
+          <CardContent className="p-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium text-blue-800">
+                Touch Mode:
+              </span>
+              <div className="flex items-center gap-2">
+                <Smartphone className="w-4 h-4 text-blue-600" />
+                <Badge variant="outline" className="text-blue-700">
+                  Tap to Play
+                </Badge>
+              </div>
+            </div>
+            <p className="text-xs text-blue-700">
+              {selectedTile
+                ? `Selected: ${selectedTile.letter || "?"} - Tap a board cell to place it`
+                : "Tap a tile from your rack to select it, then tap a board cell to place it"}
+            </p>
+            {selectedTile && (
+              <Button
+                onClick={() => setSelectedTile(null)}
+                variant="outline"
+                size="sm"
+                className="mt-2 text-xs"
+              >
+                Clear Selection
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
       {/* Game Board */}
       <Card className="overflow-hidden">
-        <CardContent className="p-2 md:p-4">
-          <div ref={boardRef} className="scrabble-board">
+        <CardContent className={cn("p-2 md:p-4", isMobile && "p-1")}>
+          <div
+            ref={boardRef}
+            className={cn(
+              "scrabble-board",
+              isMobile && "scrabble-board-mobile",
+            )}
+          >
             {gameState.board.map((row, rowIndex) =>
               row.map((cell, colIndex) =>
                 renderBoardCell(cell, rowIndex, colIndex),

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -587,13 +587,15 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
 
           {/* Action Buttons */}
           {isCurrentPlayerTurn && (
-            <div className="flex flex-wrap gap-2">
+            <div
+              className={`flex flex-wrap gap-2 ${isMobile ? "justify-center" : ""}`}
+            >
               {isExchangeMode ? (
                 <>
                   <Button
                     onClick={handleConfirmExchange}
                     disabled={selectedTilesForExchange.size === 0}
-                    className="bg-blue-600 hover:bg-blue-700"
+                    className={`bg-blue-600 hover:bg-blue-700 ${isMobile ? "flex-1 min-w-[120px]" : ""}`}
                   >
                     <CheckCircle className="w-4 h-4 mr-2" />
                     Exchange {selectedTilesForExchange.size} Tiles
@@ -604,6 +606,7 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
                       setSelectedTilesForExchange(new Set());
                     }}
                     variant="outline"
+                    className={isMobile ? "flex-1" : ""}
                   >
                     Cancel
                   </Button>
@@ -613,15 +616,16 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
                   <Button
                     onClick={handleConfirmMove}
                     disabled={placedTiles.length === 0}
-                    className="bg-green-600 hover:bg-green-700"
+                    className={`bg-green-600 hover:bg-green-700 ${isMobile ? "flex-1 min-w-[100px]" : ""}`}
                   >
                     <CheckCircle className="w-4 h-4 mr-2" />
-                    Play Word
+                    {isMobile ? "Play" : "Play Word"}
                   </Button>
                   <Button
                     onClick={handleClearBoard}
                     disabled={placedTiles.length === 0}
                     variant="outline"
+                    className={isMobile ? "flex-1" : ""}
                   >
                     <RotateCcw className="w-4 h-4 mr-2" />
                     Clear
@@ -630,15 +634,34 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
                     onClick={() => setIsExchangeMode(true)}
                     disabled={gameState.tileBag.length < 7}
                     variant="outline"
+                    className={isMobile ? "flex-1" : ""}
                   >
                     <Trash2 className="w-4 h-4 mr-2" />
-                    Exchange
+                    {isMobile ? "Swap" : "Exchange"}
                   </Button>
-                  <Button onClick={onPass} variant="outline">
-                    Pass Turn
+                  <Button
+                    onClick={onPass}
+                    variant="outline"
+                    className={isMobile ? "flex-1" : ""}
+                  >
+                    Pass
                   </Button>
                 </>
               )}
+            </div>
+          )}
+
+          {/* Clear selection button for mobile */}
+          {isMobile && selectedTile && (
+            <div className="mt-2">
+              <Button
+                onClick={() => setSelectedTile(null)}
+                variant="outline"
+                size="sm"
+                className="w-full"
+              >
+                Clear Selection ({selectedTile.letter || "?"})
+              </Button>
             </div>
           )}
 

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -288,36 +288,66 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
       position?: { row: number; col: number },
     ) => {
       const isSelected = selectedTilesForExchange.has(tile.id);
+      const isSelectedForPlacement = selectedTile?.id === tile.id;
 
       return (
         <div
           key={tile.id}
-          draggable={isCurrentPlayerTurn && !isExchangeMode}
+          draggable={!isMobile && isCurrentPlayerTurn && !isExchangeMode}
           onDragStart={(e) => {
-            if (isExchangeMode) {
+            if (isMobile || isExchangeMode) {
               e.preventDefault();
               return;
             }
             handleDragStart(tile, isPlaced ? "board" : "rack", position);
           }}
           onClick={() => {
-            if (isExchangeMode && !isPlaced) {
-              handleTileClickForExchange(tile);
-            } else if (isPlaced) {
-              handleReturnToRack(tile.id);
+            if (isMobile) {
+              handleTileSelect(tile, isPlaced ? "board" : "rack");
+            } else {
+              if (isExchangeMode && !isPlaced) {
+                handleTileClickForExchange(tile);
+              } else if (isPlaced) {
+                handleReturnToRack(tile.id);
+              }
+            }
+          }}
+          onTouchStart={(e) => {
+            // Prevent default to avoid scroll
+            if (isCurrentPlayerTurn) {
+              e.preventDefault();
             }
           }}
           className={cn(
-            "relative w-8 h-8 md:w-10 md:h-10 bg-gradient-to-br from-amber-100 to-amber-200 border-2 border-amber-400 rounded-lg flex items-center justify-center cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg",
-            isCurrentPlayerTurn && "cursor-grab active:cursor-grabbing",
+            "relative w-8 h-8 md:w-10 md:h-10 bg-gradient-to-br from-amber-100 to-amber-200 border-2 border-amber-400 rounded-lg flex items-center justify-center cursor-pointer transition-all duration-200",
+            isCurrentPlayerTurn &&
+              !isMobile &&
+              "cursor-grab active:cursor-grabbing",
+            isCurrentPlayerTurn &&
+              isMobile &&
+              "hover:scale-105 active:scale-95",
+            !isMobile && "hover:scale-105 hover:shadow-lg",
             isSelected && "ring-2 ring-blue-500 bg-blue-100",
+            isSelectedForPlacement && "ring-2 ring-purple-500 bg-purple-100",
             isPlaced && "ring-2 ring-green-500",
+            // Larger touch targets on mobile
+            isMobile && "w-10 h-10 md:w-12 md:h-12 text-sm md:text-base",
           )}
         >
-          <span className="text-xs md:text-sm font-bold text-amber-900">
+          <span
+            className={cn(
+              "font-bold text-amber-900",
+              isMobile ? "text-sm md:text-base" : "text-xs md:text-sm",
+            )}
+          >
             {tile.letter || "?"}
           </span>
-          <span className="absolute bottom-0 right-0 text-[8px] md:text-[10px] font-bold text-amber-800">
+          <span
+            className={cn(
+              "absolute bottom-0 right-0 font-bold text-amber-800",
+              isMobile ? "text-[10px] md:text-xs" : "text-[8px] md:text-[10px]",
+            )}
+          >
             {tile.value}
           </span>
           {isPlaced && (
@@ -326,21 +356,34 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
                 e.stopPropagation();
                 handleReturnToRack(tile.id);
               }}
-              className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center text-[10px] hover:bg-red-600"
+              className={cn(
+                "absolute bg-red-500 text-white rounded-full flex items-center justify-center hover:bg-red-600",
+                isMobile
+                  ? "-top-1 -right-1 w-5 h-5 text-xs"
+                  : "-top-1 -right-1 w-4 h-4 text-[10px]",
+              )}
             >
-              <X className="w-2 h-2" />
+              <X className={isMobile ? "w-3 h-3" : "w-2 h-2"} />
             </button>
+          )}
+          {isSelectedForPlacement && isMobile && (
+            <div className="absolute -top-1 -left-1 w-4 h-4 bg-purple-500 text-white rounded-full flex items-center justify-center text-[8px]">
+              ✓
+            </div>
           )}
         </div>
       );
     },
     [
+      isMobile,
       isCurrentPlayerTurn,
       isExchangeMode,
       selectedTilesForExchange,
+      selectedTile,
       handleTileClickForExchange,
       handleReturnToRack,
       handleDragStart,
+      handleTileSelect,
     ],
   );
 

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -668,8 +668,19 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
           {isExchangeMode && (
             <div className="mt-2 p-2 bg-blue-50 rounded-lg">
               <p className="text-sm text-blue-800">
-                Click tiles to select them for exchange. You can exchange up to
-                7 tiles.
+                {isMobile ? "Tap" : "Click"} tiles to select them for exchange.
+                You can exchange up to 7 tiles.
+              </p>
+            </div>
+          )}
+
+          {/* Mobile help text */}
+          {isMobile && !isExchangeMode && isCurrentPlayerTurn && (
+            <div className="mt-2 p-2 bg-green-50 rounded-lg border border-green-200">
+              <p className="text-xs text-green-800">
+                {selectedTile
+                  ? `Selected: ${selectedTile.letter || "?"} - Tap an empty board cell to place it`
+                  : "Tap a tile from your rack, then tap the board to place it"}
               </p>
             </div>
           )}

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -63,6 +63,13 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
   const isCurrentPlayerTurn =
     gameState.players[gameState.currentPlayerIndex]?.id === currentPlayerId;
 
+  // Auto-detect touch mode on mobile
+  useEffect(() => {
+    if (isMobile) {
+      setTouchMode("select");
+    }
+  }, [isMobile]);
+
   const getCellMultiplierDisplay = useCallback((row: number, col: number) => {
     const key = `${row},${col}`;
     const multiplier = BOARD_MULTIPLIERS[key];

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -395,20 +395,40 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
       const displayTile = placedTile?.tile || cell.tile;
       const multiplierText = getCellMultiplierDisplay(row, col);
       const cellColor = getCellMultiplierColor(row, col);
+      const canPlaceHere = selectedTile && !cell.tile && !placedTile;
 
       return (
         <div
           key={`${row}-${col}`}
           className={cn(
-            "relative w-6 h-6 md:w-8 md:h-8 lg:w-10 lg:h-10 border border-gray-300 flex items-center justify-center text-[8px] md:text-[10px] font-bold transition-all duration-200",
+            "relative border border-gray-300 flex items-center justify-center font-bold transition-all duration-200",
+            // Responsive sizing
+            isMobile
+              ? "w-5 h-5 md:w-7 md:h-7 text-[6px] md:text-[8px]"
+              : "w-6 h-6 md:w-8 md:h-8 lg:w-10 lg:h-10 text-[8px] md:text-[10px]",
             cellColor,
             displayTile ? "bg-gray-100" : "",
             row === 7 && col === 7 && !displayTile
               ? "text-yellow-800"
               : "text-white",
+            // Touch interaction indicators
+            canPlaceHere &&
+              isMobile &&
+              "ring-2 ring-purple-400 ring-opacity-50",
+            canPlaceHere && "cursor-pointer",
           )}
-          onDragOver={handleDragOver}
-          onDrop={(e) => handleDrop(e, row, col)}
+          onDragOver={!isMobile ? handleDragOver : undefined}
+          onDrop={!isMobile ? (e) => handleDrop(e, row, col) : undefined}
+          onClick={isMobile ? () => handleCellTouch(row, col) : undefined}
+          onTouchStart={
+            isMobile
+              ? (e) => {
+                  if (canPlaceHere) {
+                    e.preventDefault();
+                  }
+                }
+              : undefined
+          }
         >
           {displayTile ? (
             renderTile(displayTile, true, { row, col })
@@ -427,11 +447,14 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
       );
     },
     [
+      isMobile,
       placedTiles,
+      selectedTile,
       getCellMultiplierDisplay,
       getCellMultiplierColor,
       handleDragOver,
       handleDrop,
+      handleCellTouch,
       renderTile,
     ],
   );

--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -46,7 +46,9 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
   onPass,
   className,
 }) => {
+  const { isMobile } = useDeviceType();
   const [draggedTile, setDraggedTile] = useState<DraggedTile | null>(null);
+  const [selectedTile, setSelectedTile] = useState<ScrabbleTile | null>(null);
   const [placedTiles, setPlacedTiles] = useState<
     { tile: ScrabbleTile; position: { row: number; col: number } }[]
   >([]);
@@ -54,6 +56,7 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
     Set<string>
   >(new Set());
   const [isExchangeMode, setIsExchangeMode] = useState(false);
+  const [touchMode, setTouchMode] = useState<"drag" | "select">("select");
   const boardRef = useRef<HTMLDivElement>(null);
 
   const currentPlayer = gameState.players.find((p) => p.id === currentPlayerId);

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -893,8 +893,16 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
                       Waiting for more players...
                     </p>
                     <p className="text-sm text-yellow-600 mt-1">
-                      Need {Math.max(0, 2 - gameState.players.length)} more
-                      player(s) to start
+                      Need{" "}
+                      {Math.max(
+                        0,
+                        gameState.gameSettings.maxPlayers -
+                          gameState.players.length,
+                      )}{" "}
+                      more player(s) to start
+                    </p>
+                    <p className="text-xs text-yellow-500 mt-2">
+                      Game will start automatically when full
                     </p>
                   </CardContent>
                 </Card>

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -167,8 +167,6 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
   const setupGameSubscription = useCallback(() => {
     if (!currentGameId) return;
 
-    console.log(`Setting up subscription for game: ${currentGameId}`);
-
     gameSubscriptionRef.current = supabase
       .channel(`scrabble_game_${currentGameId}`)
       .on(
@@ -180,11 +178,8 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
           filter: `id=eq.${currentGameId}`,
         },
         (payload) => {
-          console.log("Received real-time update:", payload);
-
           if (payload.new && payload.new.game_state) {
             const newGameState = payload.new.game_state as ScrabbleGameState;
-            console.log("Updating game state:", newGameState);
             setGameState(newGameState);
 
             if (gameLogic) {

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -184,7 +184,7 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
 
             if (gameLogic) {
               // Update local game logic with new state
-              gameLogic.getGameState = () => newGameState;
+              gameLogic.updateGameState(newGameState);
             }
 
             // Load player profiles if we have new players
@@ -202,6 +202,24 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
                 if (newPlayer.id !== user.id) {
                   toast.success(`🎉 ${newPlayer.username} joined the game!`);
                 }
+              }
+            }
+
+            // Auto-start game when it becomes full
+            if (
+              newGameState.gameStatus === "waiting" &&
+              newGameState.players.length >= 2 && // Minimum for multiplayer
+              newGameState.players.length ===
+                newGameState.gameSettings.maxPlayers &&
+              !newGameState.gameSettings.isSinglePlayer
+            ) {
+              // Start the game automatically
+              if (gameLogic) {
+                gameLogic.forceStartGame();
+                const updatedState = gameLogic.getGameState();
+                setGameState(updatedState);
+                updateScrabbleGameState(currentGameId, updatedState);
+                toast.success("🎮 Game is starting! All players have joined!");
               }
             }
 

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -260,7 +260,7 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
         // Create game logic
         const logic = new ScrabbleGameLogic(result.gameId, {
           entryCost: entryFee,
-          maxPlayers,
+          maxPlayers: isSinglePlayer ? 1 : maxPlayers,
           isPrivate,
           isSinglePlayer,
         });

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -742,7 +742,24 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
             />
           </TabsContent>
 
-          <TabsContent value="rules">
+          <TabsContent value="rules" className="space-y-4">
+            <Card className="bg-blue-50 border-blue-200">
+              <CardContent className="p-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <BookOpen className="h-5 w-5 text-blue-600" />
+                  <span className="font-medium text-blue-800">
+                    {isMobile
+                      ? "Quick Rules Guide"
+                      : "Complete Rules & Strategy Guide"}
+                  </span>
+                </div>
+                <p className="text-sm text-blue-700">
+                  {isMobile
+                    ? "Learn the basics and mobile controls for playing Scrabble"
+                    : "Everything you need to know about playing Scrabble, including strategy tips and scoring"}
+                </p>
+              </CardContent>
+            </Card>
             <ScrabbleRules />
           </TabsContent>
 

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -349,18 +349,23 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
         .select("id, username")
         .in("id", playerIds);
 
-      // Add each player to the game logic
-      for (const playerId of playerIds) {
-        const profile = profiles?.find((p) => p.id === playerId);
-        const playerUsername =
-          playerId === user.id
-            ? user.user_metadata?.username ||
-              user.email?.split("@")[0] ||
-              "Player"
-            : profile?.username || "Player";
+      // If there's an existing game state, restore it
+      if (existingGameState) {
+        logic.updateGameState(existingGameState);
+      } else {
+        // Add each player to the game logic
+        for (const playerId of playerIds) {
+          const profile = profiles?.find((p) => p.id === playerId);
+          const playerUsername =
+            playerId === user.id
+              ? user.user_metadata?.username ||
+                user.email?.split("@")[0] ||
+                "Player"
+              : profile?.username || "Player";
 
-        const playerCoins = playerId === user.id ? userCoins : 1000; // Default coins for other players
-        logic.addPlayer(playerId, playerUsername, playerCoins);
+          const playerCoins = playerId === user.id ? userCoins : 1000; // Default coins for other players
+          logic.addPlayer(playerId, playerUsername, playerCoins);
+        }
       }
 
       setGameLogic(logic);

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -86,7 +86,7 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
 
   // Set up real-time subscription for game updates
   useEffect(() => {
-    if (currentGameId && currentView === "game") {
+    if (currentGameId) {
       setupGameSubscription();
     }
 
@@ -95,7 +95,7 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
         gameSubscriptionRef.current.unsubscribe();
       }
     };
-  }, [currentGameId, currentView]);
+  }, [currentGameId]);
 
   // Timer effect
   useEffect(() => {

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -322,16 +322,15 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
         return;
       }
 
-      // Detect if this is a single player game (max_players is 2 but created as single player)
+      // Check if this is a single player game by looking at the existing game state
+      const existingGameState = game.game_state as ScrabbleGameState | null;
       const isSinglePlayerGame =
-        game.max_players === 2 &&
-        game.is_friend_challenge &&
-        game.current_players === 1;
+        existingGameState?.gameSettings?.isSinglePlayer || false;
 
       // Create fresh game logic and add all players
       const logic = new ScrabbleGameLogic(gameId, {
         entryCost: game.entry_fee,
-        maxPlayers: isSinglePlayerGame ? 1 : game.max_players,
+        maxPlayers: game.max_players,
         isPrivate: game.is_friend_challenge,
         isSinglePlayer: isSinglePlayerGame,
       });

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -233,11 +233,9 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
           // Also handle when players join (update from scrabble_games table)
           if (payload.new && payload.eventType === "UPDATE") {
             const gameRecord = payload.new as ScrabbleGameRecord;
-            console.log("Game record updated:", gameRecord);
 
             // If we don't have a game state yet, but players have joined, reload
             if (!gameState && gameRecord.current_players > 1) {
-              console.log("Reloading game due to new players");
               // Trigger a reload of the game
               setTimeout(() => {
                 window.location.reload();
@@ -246,9 +244,7 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
           }
         },
       )
-      .subscribe((status) => {
-        console.log("Subscription status:", status);
-      });
+      .subscribe();
   }, [currentGameId, gameLogic, gameState, user.id]);
 
   const handleCreateGame = async (

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -522,90 +522,105 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          {gameState.players.map((player, index) => (
-            <div
-              key={player.id}
-              className={`flex items-center justify-between p-3 rounded-lg transition-all duration-200 ${
-                index === gameState.currentPlayerIndex
-                  ? "bg-gradient-to-r from-blue-100 to-blue-50 border-2 border-blue-300 shadow-md"
-                  : "bg-gray-50 hover:bg-gray-100"
-              }`}
-            >
-              <div className="flex items-center gap-3">
-                {/* Player Avatar */}
-                <div className="relative">
-                  <Avatar className="w-10 h-10">
-                    <AvatarImage
-                      src={playerProfiles.get(player.id)?.avatar_url || ""}
-                      alt={player.username}
-                    />
-                    <AvatarFallback
-                      className={`text-white font-bold text-sm ${
-                        player.id === user.id
-                          ? "bg-gradient-to-br from-blue-500 to-blue-600"
-                          : index === 0
-                            ? "bg-gradient-to-br from-green-500 to-green-600"
-                            : index === 1
-                              ? "bg-gradient-to-br from-purple-500 to-purple-600"
-                              : index === 2
-                                ? "bg-gradient-to-br from-orange-500 to-orange-600"
-                                : "bg-gradient-to-br from-red-500 to-red-600"
-                      }`}
-                    >
-                      {player.username.substring(0, 2).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  {index === gameState.currentPlayerIndex && (
-                    <div className="absolute -top-1 -right-1 w-5 h-5 bg-yellow-500 rounded-full flex items-center justify-center">
-                      <Crown className="h-3 w-3 text-white" />
+          {gameState.players.map((player, index) => {
+            const playerProfile = playerProfiles.get(player.id);
+            const displayName =
+              playerProfile?.username || player.username || "Player";
+
+            return (
+              <div
+                key={player.id}
+                className={`flex items-center justify-between p-3 rounded-lg transition-all duration-200 ${
+                  index === gameState.currentPlayerIndex
+                    ? "bg-gradient-to-r from-blue-100 to-blue-50 border-2 border-blue-300 shadow-md"
+                    : "bg-gray-50 hover:bg-gray-100"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  {/* Player Avatar */}
+                  <div className="relative">
+                    <Avatar className="w-10 h-10">
+                      <AvatarImage
+                        src={playerProfile?.avatar_url || ""}
+                        alt={displayName}
+                      />
+                      <AvatarFallback
+                        className={`text-white font-bold text-sm ${
+                          player.id === user.id
+                            ? "bg-gradient-to-br from-blue-500 to-blue-600"
+                            : index === 0
+                              ? "bg-gradient-to-br from-green-500 to-green-600"
+                              : index === 1
+                                ? "bg-gradient-to-br from-purple-500 to-purple-600"
+                                : index === 2
+                                  ? "bg-gradient-to-br from-orange-500 to-orange-600"
+                                  : "bg-gradient-to-br from-red-500 to-red-600"
+                        }`}
+                      >
+                        {displayName.substring(0, 2).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    {index === gameState.currentPlayerIndex &&
+                      gameState.gameStatus === "active" && (
+                        <div className="absolute -top-1 -right-1 w-5 h-5 bg-yellow-500 rounded-full flex items-center justify-center">
+                          <Crown className="h-3 w-3 text-white" />
+                        </div>
+                      )}
+                  </div>
+
+                  {/* Player Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span
+                        className={`font-medium truncate ${
+                          player.id === user.id
+                            ? "text-blue-600"
+                            : "text-gray-800"
+                        }`}
+                      >
+                        {displayName}
+                      </span>
+                      {player.id === user.id && (
+                        <Badge className="bg-blue-100 text-blue-800 text-xs">
+                          You
+                        </Badge>
+                      )}
+                      {index === gameState.currentPlayerIndex &&
+                        gameState.gameStatus === "active" && (
+                          <Badge className="bg-yellow-100 text-yellow-800 text-xs">
+                            Turn
+                          </Badge>
+                        )}
+                      {gameState.gameStatus === "waiting" && (
+                        <Badge className="bg-gray-100 text-gray-800 text-xs">
+                          Waiting
+                        </Badge>
+                      )}
                     </div>
-                  )}
+                    <div className="flex items-center gap-2 text-xs text-gray-600">
+                      <span>Position #{index + 1}</span>
+                      {gameState.gameStatus === "active" && <span>•</span>}
+                      {gameState.gameStatus === "active" && (
+                        <span>{player.rack.length} tiles</span>
+                      )}
+                      {gameState.gameStatus === "waiting" && <span>•</span>}
+                      {gameState.gameStatus === "waiting" && <span>Ready</span>}
+                    </div>
+                  </div>
                 </div>
 
-                {/* Player Info */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span
-                      className={`font-medium truncate ${
-                        player.id === user.id
-                          ? "text-blue-600"
-                          : "text-gray-800"
-                      }`}
-                    >
-                      {player.username}
-                    </span>
-                    {player.id === user.id && (
-                      <Badge className="bg-blue-100 text-blue-800 text-xs">
-                        You
-                      </Badge>
-                    )}
-                    {index === gameState.currentPlayerIndex && (
-                      <Badge className="bg-yellow-100 text-yellow-800 text-xs">
-                        Turn
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2 text-xs text-gray-600">
-                    <span>Position #{index + 1}</span>
-                    {gameState.gameStatus === "active" && <span>•</span>}
-                    {gameState.gameStatus === "active" && (
-                      <span>{player.rack.length} tiles</span>
-                    )}
+                {/* Player Stats */}
+                <div className="flex items-center gap-2">
+                  <div className="text-right">
+                    <div className="font-bold text-lg text-gray-800">
+                      {player.score}
+                    </div>
+                    <div className="text-xs text-gray-500">points</div>
                   </div>
                 </div>
               </div>
-
-              {/* Player Stats */}
-              <div className="flex items-center gap-2">
-                <div className="text-right">
-                  <div className="font-bold text-lg text-gray-800">
-                    {player.score}
-                  </div>
-                  <div className="text-xs text-gray-500">points</div>
-                </div>
-              </div>
-            </div>
-          ))}
+            );
+          })}
 
           {/* Waiting for more players - only show for multiplayer games */}
           {gameState.gameStatus === "waiting" &&

--- a/src/components/games/scrabble/ScrabbleGame.tsx
+++ b/src/components/games/scrabble/ScrabbleGame.tsx
@@ -195,6 +195,7 @@ export const ScrabbleGame: React.FC<ScrabbleGameProps> = ({ onBack, user }) => {
             // Load player profiles if we have new players
             if (newGameState.players.length > 0) {
               const playerIds = newGameState.players.map((p) => p.id);
+              // Always reload profiles to ensure we have latest data
               loadPlayerProfiles(playerIds);
 
               // Notify when a new player joins (but not for the first update)

--- a/src/components/games/scrabble/ScrabbleGameLogic.ts
+++ b/src/components/games/scrabble/ScrabbleGameLogic.ts
@@ -781,6 +781,16 @@ export class ScrabbleGameLogic {
     return this.gameState;
   }
 
+  updateGameState(newState: ScrabbleGameState): void {
+    this.gameState = newState;
+  }
+
+  forceStartGame(): void {
+    if (this.gameState.gameStatus === "waiting") {
+      this.startGame();
+    }
+  }
+
   getCurrentPlayer(): Player | null {
     if (this.gameState.players.length === 0) return null;
     return this.gameState.players[this.gameState.currentPlayerIndex];

--- a/src/components/games/scrabble/ScrabbleLobby.tsx
+++ b/src/components/games/scrabble/ScrabbleLobby.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/src/components/games/scrabble/ScrabbleRules.tsx
+++ b/src/components/games/scrabble/ScrabbleRules.tsx
@@ -24,7 +24,9 @@ import { useDeviceType } from "@/hooks/use-mobile";
 
 export const ScrabbleRules: React.FC = () => {
   const { isMobile } = useDeviceType();
-  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(
+    new Set(),
+  );
 
   const toggleSection = (section: string) => {
     const newExpanded = new Set(expandedSections);
@@ -75,8 +77,10 @@ export const ScrabbleRules: React.FC = () => {
       {/* Header */}
       <Card className="bg-gradient-to-r from-blue-500 to-purple-600 text-white border-0">
         <CardHeader className="text-center p-4 md:p-6">
-          <CardTitle className={`flex items-center justify-center gap-2 ${isMobile ? 'text-xl' : 'text-2xl'}`}>
-            <BookOpen className={`${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
+          <CardTitle
+            className={`flex items-center justify-center gap-2 ${isMobile ? "text-xl" : "text-2xl"}`}
+          >
+            <BookOpen className={`${isMobile ? "h-6 w-6" : "h-8 w-8"}`} />
             Scrabble / Words with Friends Rules
           </CardTitle>
           <p className="text-blue-100 text-sm md:text-base">
@@ -88,34 +92,66 @@ export const ScrabbleRules: React.FC = () => {
       {/* Quick Overview */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4">
         <Card className="bg-gradient-to-br from-green-500 to-green-600 text-white border-0">
-          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
-            <Users className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
-            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>2-4</div>
-            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Players</div>
+          <CardContent className={`text-center ${isMobile ? "p-3" : "p-4"}`}>
+            <Users
+              className={`mx-auto mb-1 md:mb-2 ${isMobile ? "h-6 w-6" : "h-8 w-8"}`}
+            />
+            <div className={`font-bold ${isMobile ? "text-lg" : "text-2xl"}`}>
+              2-4
+            </div>
+            <div
+              className={`opacity-90 ${isMobile ? "text-[10px]" : "text-xs"}`}
+            >
+              Players
+            </div>
           </CardContent>
         </Card>
 
         <Card className="bg-gradient-to-br from-blue-500 to-blue-600 text-white border-0">
-          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
-            <Clock className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
-            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>5 min</div>
-            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Per Turn</div>
+          <CardContent className={`text-center ${isMobile ? "p-3" : "p-4"}`}>
+            <Clock
+              className={`mx-auto mb-1 md:mb-2 ${isMobile ? "h-6 w-6" : "h-8 w-8"}`}
+            />
+            <div className={`font-bold ${isMobile ? "text-lg" : "text-2xl"}`}>
+              5 min
+            </div>
+            <div
+              className={`opacity-90 ${isMobile ? "text-[10px]" : "text-xs"}`}
+            >
+              Per Turn
+            </div>
           </CardContent>
         </Card>
 
         <Card className="bg-gradient-to-br from-purple-500 to-purple-600 text-white border-0">
-          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
-            <Target className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
-            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>7</div>
-            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Tiles per Player</div>
+          <CardContent className={`text-center ${isMobile ? "p-3" : "p-4"}`}>
+            <Target
+              className={`mx-auto mb-1 md:mb-2 ${isMobile ? "h-6 w-6" : "h-8 w-8"}`}
+            />
+            <div className={`font-bold ${isMobile ? "text-lg" : "text-2xl"}`}>
+              7
+            </div>
+            <div
+              className={`opacity-90 ${isMobile ? "text-[10px]" : "text-xs"}`}
+            >
+              Tiles per Player
+            </div>
           </CardContent>
         </Card>
 
         <Card className="bg-gradient-to-br from-orange-500 to-orange-600 text-white border-0">
-          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
-            <Trophy className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
-            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>50</div>
-            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Bonus for 7 tiles</div>
+          <CardContent className={`text-center ${isMobile ? "p-3" : "p-4"}`}>
+            <Trophy
+              className={`mx-auto mb-1 md:mb-2 ${isMobile ? "h-6 w-6" : "h-8 w-8"}`}
+            />
+            <div className={`font-bold ${isMobile ? "text-lg" : "text-2xl"}`}>
+              50
+            </div>
+            <div
+              className={`opacity-90 ${isMobile ? "text-[10px]" : "text-xs"}`}
+            >
+              Bonus for 7 tiles
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -137,7 +173,9 @@ export const ScrabbleRules: React.FC = () => {
                 </div>
                 <div className="flex-1">
                   <p className="font-medium text-sm">Select a Tile</p>
-                  <p className="text-xs text-gray-600">Tap any tile from your rack to select it</p>
+                  <p className="text-xs text-gray-600">
+                    Tap any tile from your rack to select it
+                  </p>
                 </div>
               </div>
 
@@ -147,7 +185,9 @@ export const ScrabbleRules: React.FC = () => {
                 </div>
                 <div className="flex-1">
                   <p className="font-medium text-sm">Place on Board</p>
-                  <p className="text-xs text-gray-600">Tap any empty cell on the board to place your tile</p>
+                  <p className="text-xs text-gray-600">
+                    Tap any empty cell on the board to place your tile
+                  </p>
                 </div>
               </div>
 
@@ -157,13 +197,17 @@ export const ScrabbleRules: React.FC = () => {
                 </div>
                 <div className="flex-1">
                   <p className="font-medium text-sm">Confirm Move</p>
-                  <p className="text-xs text-gray-600">Tap "Play Word" when you're ready to submit</p>
+                  <p className="text-xs text-gray-600">
+                    Tap "Play Word" when you're ready to submit
+                  </p>
                 </div>
               </div>
             </div>
 
             <div className="p-3 bg-yellow-50 rounded-lg border border-yellow-200">
-              <p className="text-sm text-yellow-800 font-medium mb-1">💡 Pro Tips:</p>
+              <p className="text-sm text-yellow-800 font-medium mb-1">
+                💡 Pro Tips:
+              </p>
               <ul className="text-xs text-yellow-700 space-y-1">
                 <li>• Selected tiles show a purple highlight</li>
                 <li>• Valid placement spots show subtle highlights</li>
@@ -176,270 +220,333 @@ export const ScrabbleRules: React.FC = () => {
       )}
 
       <Tabs defaultValue="basics" className="w-full">
-        <TabsList className={`grid w-full ${isMobile ? 'grid-cols-2' : 'grid-cols-4'}`}>
-          <TabsTrigger value="basics" className={isMobile ? 'text-xs' : 'text-sm'}>Basics</TabsTrigger>
-          <TabsTrigger value="scoring" className={isMobile ? 'text-xs' : 'text-sm'}>Scoring</TabsTrigger>
-          {!isMobile && <TabsTrigger value="strategy" className="text-sm">Strategy</TabsTrigger>}
-          {!isMobile && <TabsTrigger value="coins" className="text-sm">Coins</TabsTrigger>}
+        <TabsList
+          className={`grid w-full ${isMobile ? "grid-cols-2" : "grid-cols-4"}`}
+        >
+          <TabsTrigger
+            value="basics"
+            className={isMobile ? "text-xs" : "text-sm"}
+          >
+            Basics
+          </TabsTrigger>
+          <TabsTrigger
+            value="scoring"
+            className={isMobile ? "text-xs" : "text-sm"}
+          >
+            Scoring
+          </TabsTrigger>
+          {!isMobile && (
+            <TabsTrigger value="strategy" className="text-sm">
+              Strategy
+            </TabsTrigger>
+          )}
+          {!isMobile && (
+            <TabsTrigger value="coins" className="text-sm">
+              Coins
+            </TabsTrigger>
+          )}
           {isMobile && (
-            <TabsTrigger value="more" className="text-xs">More</TabsTrigger>
+            <TabsTrigger value="more" className="text-xs">
+              More
+            </TabsTrigger>
           )}
         </TabsList>
 
-        <TabsContent value="basics" className="space-y-4">{/* Basics content will go here */}
+        <TabsContent value="basics" className="space-y-4">
+          {/* Basic Rules */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Brain className="h-6 w-6 text-blue-600" />
+                How to Play
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <h3 className="font-bold text-lg mb-3 text-green-700">
+                    🎯 Objective
+                  </h3>
+                  <p className="text-gray-700 mb-4">
+                    Score the most points by forming words on the game board
+                    using letter tiles.
+                  </p>
 
-      {/* Basic Rules */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Brain className="h-6 w-6 text-blue-600" />
-            How to Play
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <h3 className="font-bold text-lg mb-3 text-green-700">
-                🎯 Objective
-              </h3>
-              <p className="text-gray-700 mb-4">
-                Score the most points by forming words on the game board using
-                letter tiles.
-              </p>
-
-              <h3 className="font-bold text-lg mb-3 text-blue-700">
-                🎮 Game Setup
-              </h3>
-              <ul className="space-y-2 text-gray-700">
-                <li>• Each player draws 7 letter tiles</li>
-                <li>• 100 tiles total in the game</li>
-                <li>• 15×15 game board with special squares</li>
-                <li>• First word must cross the center star</li>
-              </ul>
-            </div>
-
-            <div>
-              <h3 className="font-bold text-lg mb-3 text-purple-700">
-                ⚡ Turn Actions
-              </h3>
-              <p className="text-gray-700 mb-2">On your turn, you can:</p>
-              <ul className="space-y-2 text-gray-700">
-                <li>
-                  • <strong>Play Word:</strong> Place tiles to form a valid word
-                </li>
-                <li>
-                  • <strong>Exchange Tiles:</strong> Swap tiles with the bag
-                  (lose turn)
-                </li>
-                <li>
-                  • <strong>Pass:</strong> Skip your turn (no penalty)
-                </li>
-              </ul>
-
-              <h3 className="font-bold text-lg mb-3 mt-4 text-orange-700">
-                🏆 Scoring
-              </h3>
-              <ul className="space-y-2 text-gray-700">
-                <li>• Sum of all letter values in words formed</li>
-                <li>• Multipliers apply only to new tiles</li>
-                <li>• +50 bonus for using all 7 tiles</li>
-                <li>• Game ends when tiles run out or no moves possible</li>
-              </ul>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Letter Values */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Star className="h-6 w-6 text-yellow-600" />
-            Letter Values
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {letterValues.map((group, index) => (
-              <div
-                key={index}
-                className="flex items-center justify-between p-3 border rounded-lg"
-              >
-                <span className="font-medium text-gray-700">
-                  {group.letters}
-                </span>
-                <Badge
-                  variant={
-                    group.value <= 1
-                      ? "secondary"
-                      : group.value <= 4
-                        ? "default"
-                        : "destructive"
-                  }
-                  className="font-bold"
-                >
-                  {group.value} {group.value === 1 ? "point" : "points"}
-                </Badge>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Special Squares */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Zap className="h-6 w-6 text-purple-600" />
-            Special Board Squares
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {specialSquares.map((square, index) => (
-              <div key={index} className="p-4 border rounded-lg">
-                <div className="flex items-center gap-3 mb-2">
-                  <div
-                    className="w-4 h-4 rounded"
-                    style={{
-                      backgroundColor:
-                        square.color === "Red"
-                          ? "#ef4444"
-                          : square.color === "Pink"
-                            ? "#ec4899"
-                            : square.color === "Blue"
-                              ? "#3b82f6"
-                              : "#06b6d4",
-                    }}
-                  ></div>
-                  <span className="font-bold">{square.type}</span>
+                  <h3 className="font-bold text-lg mb-3 text-blue-700">
+                    🎮 Game Setup
+                  </h3>
+                  <ul className="space-y-2 text-gray-700">
+                    <li>• Each player draws 7 letter tiles</li>
+                    <li>• 100 tiles total in the game</li>
+                    <li>• 15×15 game board with special squares</li>
+                    <li>• First word must cross the center star</li>
+                  </ul>
                 </div>
-                <p className="text-sm text-gray-600">{square.description}</p>
+
+                <div>
+                  <h3 className="font-bold text-lg mb-3 text-purple-700">
+                    ⚡ Turn Actions
+                  </h3>
+                  <p className="text-gray-700 mb-2">On your turn, you can:</p>
+                  <ul className="space-y-2 text-gray-700">
+                    <li>
+                      • <strong>Play Word:</strong> Place tiles to form a valid
+                      word
+                    </li>
+                    <li>
+                      • <strong>Exchange Tiles:</strong> Swap tiles with the bag
+                      (lose turn)
+                    </li>
+                    <li>
+                      • <strong>Pass:</strong> Skip your turn (no penalty)
+                    </li>
+                  </ul>
+
+                  <h3 className="font-bold text-lg mb-3 mt-4 text-orange-700">
+                    🏆 Game End
+                  </h3>
+                  <ul className="space-y-2 text-gray-700">
+                    <li>• Game ends when tiles run out</li>
+                    <li>• Player with highest score wins</li>
+                    <li>• Subtract remaining tile values</li>
+                  </ul>
+                </div>
               </div>
-            ))}
-          </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
 
-          <div className="mt-4 p-4 bg-yellow-50 rounded-lg border border-yellow-200">
-            <p className="text-sm text-yellow-800">
-              <strong>Important:</strong> Multipliers only apply to newly placed
-              tiles in that turn, not to existing tiles on the board.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+        <TabsContent value="scoring" className="space-y-4">
+          {/* Letter Values */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Star className="h-6 w-6 text-yellow-600" />
+                Letter Values
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {letterValues.map((group, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center justify-between p-3 border rounded-lg"
+                  >
+                    <span className="font-medium text-gray-700">
+                      {group.letters}
+                    </span>
+                    <Badge
+                      variant={
+                        group.value <= 1
+                          ? "secondary"
+                          : group.value <= 4
+                            ? "default"
+                            : "destructive"
+                      }
+                      className="font-bold"
+                    >
+                      {group.value} {group.value === 1 ? "point" : "points"}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
 
-      {/* Coin System */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Coins className="h-6 w-6 text-yellow-600" />
-            Coin System & Rewards
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="p-4 bg-green-50 rounded-lg border border-green-200">
-              <h3 className="font-bold text-green-800 mb-2">🆓 Free Games</h3>
-              <p className="text-sm text-green-700">
-                Play without entry fees to practice and improve your skills.
-              </p>
-            </div>
+          {/* Special Squares */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Zap className="h-6 w-6 text-purple-600" />
+                Special Board Squares
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {specialSquares.map((square, index) => (
+                  <div key={index} className="p-4 border rounded-lg">
+                    <div className="flex items-center gap-3 mb-2">
+                      <div
+                        className="w-4 h-4 rounded"
+                        style={{
+                          backgroundColor:
+                            square.color === "Red"
+                              ? "#ef4444"
+                              : square.color === "Pink"
+                                ? "#ec4899"
+                                : square.color === "Blue"
+                                  ? "#3b82f6"
+                                  : "#06b6d4",
+                        }}
+                      ></div>
+                      <span className="font-bold">{square.type}</span>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      {square.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
 
-            <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
-              <h3 className="font-bold text-blue-800 mb-2">💰 Coin Games</h3>
-              <p className="text-sm text-blue-700">
-                Entry fee games where winners take the entire prize pool.
-              </p>
-            </div>
+              <div className="mt-4 p-4 bg-yellow-50 rounded-lg border border-yellow-200">
+                <p className="text-sm text-yellow-800">
+                  <strong>Important:</strong> Multipliers only apply to newly
+                  placed tiles in that turn, not to existing tiles on the board.
+                </p>
+              </div>
 
-            <div className="p-4 bg-purple-50 rounded-lg border border-purple-200">
-              <h3 className="font-bold text-purple-800 mb-2">🎁 Daily Bonus</h3>
-              <p className="text-sm text-purple-700">
-                Get free coins daily just for playing and staying active.
-              </p>
-            </div>
-          </div>
+              <div className="mt-4 p-4 bg-green-50 rounded-lg border border-green-200">
+                <h4 className="font-bold text-green-800 mb-2">Scoring Tips:</h4>
+                <ul className="text-sm text-green-700 space-y-1">
+                  <li>• +50 bonus for using all 7 tiles in one turn</li>
+                  <li>• Form multiple words in one turn for more points</li>
+                  <li>• Multipliers apply to the entire word when used</li>
+                  <li>• Plan ahead to use high-value squares</li>
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
 
-          <div className="p-4 bg-gray-50 rounded-lg">
-            <h3 className="font-bold mb-2">Starting Package</h3>
-            <p className="text-sm text-gray-700">
-              • New players get 1000 free coins to start playing
-              <br />
-              • Practice in free games to learn strategies
-              <br />• Buy more coins anytime to join premium games
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+        {!isMobile && (
+          <TabsContent value="strategy" className="space-y-4">
+            {/* Strategy Tips */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Brain className="h-6 w-6 text-indigo-600" />
+                  Strategy Tips
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div>
+                    <h3 className="font-bold text-lg mb-3 text-green-700">
+                      🎯 Scoring Tips
+                    </h3>
+                    <ul className="space-y-2 text-gray-700">
+                      <li>• Look for high-value letters (J, Q, X, Z)</li>
+                      <li>• Use multiplier squares strategically</li>
+                      <li>• Try to use all 7 tiles for 50-point bonus</li>
+                      <li>• Form multiple words in one turn when possible</li>
+                    </ul>
+                  </div>
 
-      {/* Strategy Tips */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Brain className="h-6 w-6 text-indigo-600" />
-            Strategy Tips
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <h3 className="font-bold text-lg mb-3 text-green-700">
-                🎯 Scoring Tips
-              </h3>
-              <ul className="space-y-2 text-gray-700">
-                <li>• Look for high-value letters (J, Q, X, Z)</li>
-                <li>• Use multiplier squares strategically</li>
-                <li>• Try to use all 7 tiles for 50-point bonus</li>
-                <li>• Form multiple words in one turn when possible</li>
-              </ul>
-            </div>
+                  <div>
+                    <h3 className="font-bold text-lg mb-3 text-blue-700">
+                      🧠 Advanced Strategy
+                    </h3>
+                    <ul className="space-y-2 text-gray-700">
+                      <li>• Keep a balanced rack of vowels and consonants</li>
+                      <li>• Block opponents from premium squares</li>
+                      <li>• Save blank tiles for high-scoring opportunities</li>
+                      <li>• Learn common 2-letter words (QI, XI, etc.)</li>
+                    </ul>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
 
-            <div>
-              <h3 className="font-bold text-lg mb-3 text-blue-700">
-                🧠 Advanced Strategy
-              </h3>
-              <ul className="space-y-2 text-gray-700">
-                <li>• Keep a balanced rack of vowels and consonants</li>
-                <li>• Block opponents from premium squares</li>
-                <li>• Save blank tiles for high-scoring opportunities</li>
-                <li>• Learn common 2-letter words (QI, XI, etc.)</li>
-              </ul>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+        {!isMobile && (
+          <TabsContent value="coins" className="space-y-4">
+            {/* Coin System */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Coins className="h-6 w-6 text-yellow-600" />
+                  Coin System & Rewards
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+                    <h3 className="font-bold text-green-800 mb-2">
+                      🆓 Free Games
+                    </h3>
+                    <p className="text-sm text-green-700">
+                      Play without entry fees to practice and improve your
+                      skills.
+                    </p>
+                  </div>
 
-      {/* Game End */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Trophy className="h-6 w-6 text-yellow-600" />
-            Game End & Winning
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div>
-              <h3 className="font-bold text-lg mb-2">Game Ends When:</h3>
-              <ul className="list-disc list-inside space-y-1 text-gray-700">
-                <li>A player uses all their tiles (and tile bag is empty)</li>
-                <li>No player can make a valid move</li>
-                <li>All players pass their turn consecutively</li>
-              </ul>
-            </div>
+                  <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
+                    <h3 className="font-bold text-blue-800 mb-2">
+                      💰 Coin Games
+                    </h3>
+                    <p className="text-sm text-blue-700">
+                      Entry fee games where winners take the entire prize pool.
+                    </p>
+                  </div>
 
-            <div>
-              <h3 className="font-bold text-lg mb-2">Final Scoring:</h3>
-              <ul className="list-disc list-inside space-y-1 text-gray-700">
-                <li>Subtract remaining tile values from each player's score</li>
-                <li>Player with the highest score wins</li>
-                <li>Winner receives the entire prize pool (in coin games)</li>
-                <li>Ties are broken by who finished first</li>
-              </ul>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+                  <div className="p-4 bg-purple-50 rounded-lg border border-purple-200">
+                    <h3 className="font-bold text-purple-800 mb-2">
+                      🎁 Daily Bonus
+                    </h3>
+                    <p className="text-sm text-purple-700">
+                      Get free coins daily just for playing and staying active.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="p-4 bg-gray-50 rounded-lg">
+                  <h3 className="font-bold mb-2">Starting Package</h3>
+                  <p className="text-sm text-gray-700">
+                    • New players get 1000 free coins to start playing
+                    <br />
+                    • Practice in free games to learn strategies
+                    <br />• Buy more coins anytime to join premium games
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
+
+        {isMobile && (
+          <TabsContent value="more" className="space-y-4">
+            {/* Combined Strategy and Coins for Mobile */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Brain className="h-6 w-6 text-indigo-600" />
+                  Strategy & Tips
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <h3 className="font-bold text-lg mb-3 text-green-700">
+                    🎯 Quick Tips
+                  </h3>
+                  <ul className="space-y-2 text-gray-700 text-sm">
+                    <li>
+                      • Use high-value letters (J, Q, X, Z) on multiplier
+                      squares
+                    </li>
+                    <li>• Try to use all 7 tiles for 50-point bonus</li>
+                    <li>• Form multiple words in one turn when possible</li>
+                    <li>• Keep a balanced mix of vowels and consonants</li>
+                    <li>• Learn common 2-letter words (QI, XI, etc.)</li>
+                  </ul>
+                </div>
+
+                <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
+                  <h3 className="font-bold text-blue-800 mb-2">
+                    💰 Coin System
+                  </h3>
+                  <ul className="text-sm text-blue-700 space-y-1">
+                    <li>• New players get 1000 free coins</li>
+                    <li>• Play free games to practice</li>
+                    <li>• Win coin games to earn more</li>
+                    <li>• Daily bonuses available</li>
+                  </ul>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
+      </Tabs>
     </div>
   );
 };

--- a/src/components/games/scrabble/ScrabbleRules.tsx
+++ b/src/components/games/scrabble/ScrabbleRules.tsx
@@ -24,9 +24,7 @@ import { useDeviceType } from "@/hooks/use-mobile";
 
 export const ScrabbleRules: React.FC = () => {
   const { isMobile } = useDeviceType();
-  const [expandedSections, setExpandedSections] = useState<Set<string>>(
-    new Set(),
-  );
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
 
   const toggleSection = (section: string) => {
     const newExpanded = new Set(expandedSections);
@@ -77,10 +75,8 @@ export const ScrabbleRules: React.FC = () => {
       {/* Header */}
       <Card className="bg-gradient-to-r from-blue-500 to-purple-600 text-white border-0">
         <CardHeader className="text-center p-4 md:p-6">
-          <CardTitle
-            className={`flex items-center justify-center gap-2 ${isMobile ? "text-xl" : "text-2xl"}`}
-          >
-            <BookOpen className={`${isMobile ? "h-6 w-6" : "h-8 w-8"}`} />
+          <CardTitle className={`flex items-center justify-center gap-2 ${isMobile ? 'text-xl' : 'text-2xl'}`}>
+            <BookOpen className={`${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
             Scrabble / Words with Friends Rules
           </CardTitle>
           <p className="text-blue-100 text-sm md:text-base">
@@ -90,39 +86,107 @@ export const ScrabbleRules: React.FC = () => {
       </Card>
 
       {/* Quick Overview */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4">
         <Card className="bg-gradient-to-br from-green-500 to-green-600 text-white border-0">
-          <CardContent className="p-4 text-center">
-            <Users className="h-8 w-8 mx-auto mb-2" />
-            <div className="text-2xl font-bold">2-4</div>
-            <div className="text-xs opacity-90">Players</div>
+          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
+            <Users className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
+            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>2-4</div>
+            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Players</div>
           </CardContent>
         </Card>
 
         <Card className="bg-gradient-to-br from-blue-500 to-blue-600 text-white border-0">
-          <CardContent className="p-4 text-center">
-            <Clock className="h-8 w-8 mx-auto mb-2" />
-            <div className="text-2xl font-bold">5 min</div>
-            <div className="text-xs opacity-90">Per Turn</div>
+          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
+            <Clock className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
+            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>5 min</div>
+            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Per Turn</div>
           </CardContent>
         </Card>
 
         <Card className="bg-gradient-to-br from-purple-500 to-purple-600 text-white border-0">
-          <CardContent className="p-4 text-center">
-            <Target className="h-8 w-8 mx-auto mb-2" />
-            <div className="text-2xl font-bold">7</div>
-            <div className="text-xs opacity-90">Tiles per Player</div>
+          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
+            <Target className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
+            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>7</div>
+            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Tiles per Player</div>
           </CardContent>
         </Card>
 
         <Card className="bg-gradient-to-br from-orange-500 to-orange-600 text-white border-0">
-          <CardContent className="p-4 text-center">
-            <Trophy className="h-8 w-8 mx-auto mb-2" />
-            <div className="text-2xl font-bold">50</div>
-            <div className="text-xs opacity-90">Bonus for 7 tiles</div>
+          <CardContent className={`text-center ${isMobile ? 'p-3' : 'p-4'}`}>
+            <Trophy className={`mx-auto mb-1 md:mb-2 ${isMobile ? 'h-6 w-6' : 'h-8 w-8'}`} />
+            <div className={`font-bold ${isMobile ? 'text-lg' : 'text-2xl'}`}>50</div>
+            <div className={`opacity-90 ${isMobile ? 'text-[10px]' : 'text-xs'}`}>Bonus for 7 tiles</div>
           </CardContent>
         </Card>
       </div>
+
+      {/* Mobile Controls Guide */}
+      {isMobile && (
+        <Card className="bg-gradient-to-br from-purple-50 to-blue-50 border-purple-200">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Smartphone className="h-5 w-5 text-purple-600" />
+              Mobile Controls
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 gap-3">
+              <div className="flex items-center gap-3 p-3 bg-white rounded-lg border">
+                <div className="w-8 h-8 bg-purple-500 rounded-full flex items-center justify-center text-white text-sm font-bold">
+                  1
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-sm">Select a Tile</p>
+                  <p className="text-xs text-gray-600">Tap any tile from your rack to select it</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 p-3 bg-white rounded-lg border">
+                <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-bold">
+                  2
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-sm">Place on Board</p>
+                  <p className="text-xs text-gray-600">Tap any empty cell on the board to place your tile</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 p-3 bg-white rounded-lg border">
+                <div className="w-8 h-8 bg-green-500 rounded-full flex items-center justify-center text-white text-sm font-bold">
+                  3
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-sm">Confirm Move</p>
+                  <p className="text-xs text-gray-600">Tap "Play Word" when you're ready to submit</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-3 bg-yellow-50 rounded-lg border border-yellow-200">
+              <p className="text-sm text-yellow-800 font-medium mb-1">💡 Pro Tips:</p>
+              <ul className="text-xs text-yellow-700 space-y-1">
+                <li>• Selected tiles show a purple highlight</li>
+                <li>• Valid placement spots show subtle highlights</li>
+                <li>• Tap placed tiles to remove them</li>
+                <li>• Use "Clear" to remove all placed tiles</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Tabs defaultValue="basics" className="w-full">
+        <TabsList className={`grid w-full ${isMobile ? 'grid-cols-2' : 'grid-cols-4'}`}>
+          <TabsTrigger value="basics" className={isMobile ? 'text-xs' : 'text-sm'}>Basics</TabsTrigger>
+          <TabsTrigger value="scoring" className={isMobile ? 'text-xs' : 'text-sm'}>Scoring</TabsTrigger>
+          {!isMobile && <TabsTrigger value="strategy" className="text-sm">Strategy</TabsTrigger>}
+          {!isMobile && <TabsTrigger value="coins" className="text-sm">Coins</TabsTrigger>}
+          {isMobile && (
+            <TabsTrigger value="more" className="text-xs">More</TabsTrigger>
+          )}
+        </TabsList>
+
+        <TabsContent value="basics" className="space-y-4">{/* Basics content will go here */}
 
       {/* Basic Rules */}
       <Card>

--- a/src/components/games/scrabble/ScrabbleRules.tsx
+++ b/src/components/games/scrabble/ScrabbleRules.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   BookOpen,
   Target,
@@ -11,7 +13,14 @@ import {
   Users,
   Brain,
   Zap,
+  Smartphone,
+  Mouse,
+  ArrowDown,
+  ArrowRight,
+  ChevronDown,
+  ChevronUp,
 } from "lucide-react";
+import { useDeviceType } from "@/hooks/use-mobile";
 
 export const ScrabbleRules: React.FC = () => {
   const letterValues = [

--- a/src/components/games/scrabble/ScrabbleRules.tsx
+++ b/src/components/games/scrabble/ScrabbleRules.tsx
@@ -73,15 +73,17 @@ export const ScrabbleRules: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 md:space-y-6">
       {/* Header */}
       <Card className="bg-gradient-to-r from-blue-500 to-purple-600 text-white border-0">
-        <CardHeader className="text-center">
-          <CardTitle className="flex items-center justify-center gap-2 text-2xl">
-            <BookOpen className="h-8 w-8" />
+        <CardHeader className="text-center p-4 md:p-6">
+          <CardTitle
+            className={`flex items-center justify-center gap-2 ${isMobile ? "text-xl" : "text-2xl"}`}
+          >
+            <BookOpen className={`${isMobile ? "h-6 w-6" : "h-8 w-8"}`} />
             Scrabble / Words with Friends Rules
           </CardTitle>
-          <p className="text-blue-100">
+          <p className="text-blue-100 text-sm md:text-base">
             Master the art of word-building and strategy!
           </p>
         </CardHeader>

--- a/src/components/games/scrabble/ScrabbleRules.tsx
+++ b/src/components/games/scrabble/ScrabbleRules.tsx
@@ -23,6 +23,21 @@ import {
 import { useDeviceType } from "@/hooks/use-mobile";
 
 export const ScrabbleRules: React.FC = () => {
+  const { isMobile } = useDeviceType();
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const toggleSection = (section: string) => {
+    const newExpanded = new Set(expandedSections);
+    if (newExpanded.has(section)) {
+      newExpanded.delete(section);
+    } else {
+      newExpanded.add(section);
+    }
+    setExpandedSections(newExpanded);
+  };
+
   const letterValues = [
     { letters: "A, E, I, O, U, L, N, S, T, R", value: 1 },
     { letters: "D, G", value: 2 },

--- a/src/components/games/scrabble/scrabble.css
+++ b/src/components/games/scrabble/scrabble.css
@@ -170,27 +170,124 @@
   }
 }
 
+/* Mobile-specific board layout */
+.scrabble-board-mobile {
+  display: grid;
+  grid-template-columns: repeat(15, 1fr);
+  gap: 0.5px;
+  background-color: #374151;
+  padding: 4px;
+  border-radius: 6px;
+  max-width: 100%;
+  margin: 0 auto;
+  overflow-x: auto;
+}
+
+/* Touch-friendly interactions */
+.touch-tile {
+  touch-action: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.touch-cell {
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.touch-cell.can-place {
+  background-color: rgba(147, 51, 234, 0.1) !important;
+  border: 2px dashed rgba(147, 51, 234, 0.5) !important;
+}
+
+/* Mobile animations */
+.mobile-tile-select {
+  animation: mobileSelect 0.2s ease-out;
+}
+
+@keyframes mobileSelect {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1.05);
+  }
+}
+
+.mobile-tile-place {
+  animation: mobilePlace 0.3s ease-out;
+}
+
+@keyframes mobilePlace {
+  0% {
+    transform: scale(1.2);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
 /* Responsive adjustments */
 @media (max-width: 640px) {
   .scrabble-board {
-    padding: 4px;
+    padding: 2px;
     gap: 0.5px;
+    max-width: 100vw;
+    overflow-x: auto;
   }
 
   .scrabble-cell {
-    width: 20px;
-    height: 20px;
-    font-size: 7px;
+    width: 18px;
+    height: 18px;
+    font-size: 6px;
+    min-width: 18px;
+    min-height: 18px;
+  }
+
+  .scrabble-tile {
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
+    border-width: 2px;
+    min-width: 32px;
+    min-height: 32px;
+  }
+
+  .scrabble-tile-value {
+    font-size: 8px;
+  }
+
+  /* Ensure board doesn't overflow */
+  .scrabble-board,
+  .scrabble-board-mobile {
+    max-width: calc(100vw - 32px);
+  }
+}
+
+@media (max-width: 480px) {
+  .scrabble-cell {
+    width: 16px;
+    height: 16px;
+    font-size: 5px;
+    min-width: 16px;
+    min-height: 16px;
   }
 
   .scrabble-tile {
     width: 28px;
     height: 28px;
     font-size: 12px;
-    border-width: 1px;
   }
 
-  .scrabble-tile-value {
-    font-size: 7px;
+  .scrabble-board,
+  .scrabble-board-mobile {
+    padding: 1px;
+    gap: 0.25px;
+    max-width: calc(100vw - 16px);
   }
 }

--- a/src/utils/scrabbleDbHelper.ts
+++ b/src/utils/scrabbleDbHelper.ts
@@ -72,7 +72,7 @@ export const createScrabbleGame = async (
       player3_id: null,
       player4_id: null,
       current_players: 1,
-      max_players: isSinglePlayer ? 2 : maxPlayers, // Set to 2 for single player to satisfy DB constraint
+      max_players: maxPlayers >= 2 ? maxPlayers : 2, // Ensure at least 2 to satisfy DB constraint
       entry_fee: entryFee,
       prize_amount: entryFee, // Initial prize pool
       winner_id: null,


### PR DESCRIPTION
Adds comprehensive mobile touch support to the Scrabble game component:

**ScrabbleBoard.tsx changes:**
- Import useEffect and useDeviceType hook for mobile detection
- Add Smartphone and Mouse icons from lucide-react
- Add selectedTile state for touch-based tile selection
- Add touchMode state with "drag" or "select" modes
- Auto-detect and set touch mode to "select" on mobile devices
- Implement handleCellTouch function for placing tiles via touch
- Implement handleTileSelect function for selecting tiles on mobile
- Update tile rendering with mobile-specific styling and touch handlers
- Add visual indicators for selected tiles on mobile
- Increase touch target sizes on mobile devices
- Disable drag functionality on mobile, use touch selection instead
- Add touch-friendly cell highlighting for tile placement

**CSS changes (scrabble.css):**
- Add mobile-specific board layout with scrabble-board-mobile class
- Add touch-friendly interaction styles (touch-tile, touch-cell)
- Add visual feedback for tile placement areas (can-place styling)
- Add mobile-specific animations (mobileSelect, mobilePlace)
- Improve responsive design for smaller screens (640px, 480px breakpoints)
- Ensure board doesn't overflow on mobile devices
- Adjust tile and cell sizes for better mobile usability

**Database helper fix:**
- Fix maxPlayers constraint to ensure minimum value of 2

The changes maintain backward compatibility with desktop drag-and-drop while providing an intuitive touch interface for mobile users.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a7cc7abac2fe422c9903f9b9cea2b4ba/spark-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a7cc7abac2fe422c9903f9b9cea2b4ba</projectId>-->
<!--<branchName>spark-haven</branchName>-->