### PR TITLE
Move handleTileClickForExchange function up in ScrabbleBoard

### DIFF
--- a/src/components/games/scrabble/ScrabbleBoard.tsx
+++ b/src/components/games/scrabble/ScrabbleBoard.tsx
@@ -214,6 +214,23 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
     ],
   );
 
+  const handleTileClickForExchange = useCallback(
+    (tile: ScrabbleTile) => {
+      if (!isExchangeMode || !isCurrentPlayerTurn) return;
+
+      setSelectedTilesForExchange((prev) => {
+        const newSet = new Set(prev);
+        if (newSet.has(tile.id)) {
+          newSet.delete(tile.id);
+        } else {
+          newSet.add(tile.id);
+        }
+        return newSet;
+      });
+    },
+    [isExchangeMode, isCurrentPlayerTurn],
+  );
+
   // Handle tile selection for mobile
   const handleTileSelect = useCallback(
     (tile: ScrabbleTile, source: "rack" | "board") => {
@@ -251,23 +268,6 @@ export const ScrabbleBoard: React.FC<ScrabbleBoardProps> = ({
     onPlaceTiles(placedTiles);
     setPlacedTiles([]);
   }, [placedTiles, onPlaceTiles]);
-
-  const handleTileClickForExchange = useCallback(
-    (tile: ScrabbleTile) => {
-      if (!isExchangeMode || !isCurrentPlayerTurn) return;
-
-      setSelectedTilesForExchange((prev) => {
-        const newSet = new Set(prev);
-        if (newSet.has(tile.id)) {
-          newSet.delete(tile.id);
-        } else {
-          newSet.add(tile.id);
-        }
-        return newSet;
-      });
-    },
-    [isExchangeMode, isCurrentPlayerTurn],
-  );
 
   const handleConfirmExchange = useCallback(() => {
     if (selectedTilesForExchange.size === 0 || !currentPlayer) return;


### PR DESCRIPTION
Moved the handleTileClickForExchange function to an earlier position in the ScrabbleBoard component.

The function was relocated from line 255 to line 217, placing it before the handleTileSelect function. The function implementation remains unchanged - it still handles tile selection for exchange mode with the same logic and dependencies.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 36`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a7cc7abac2fe422c9903f9b9cea2b4ba/cosmos-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a7cc7abac2fe422c9903f9b9cea2b4ba</projectId>-->
<!--<branchName>cosmos-hub</branchName>-->