### PR TITLE
Fix syntax error in error code comparison

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -69,7 +69,7 @@ const Index = () => {
         .eq("id", userId)
         .single();
 
-     if (error && error.code ! "PGRST116") {
+      if (error && error.code !== "PGRST116") {
         console.error("Profile fetch error:", {
           message: error.message,
           details: error.details,


### PR DESCRIPTION
Fixed a syntax error in the error code comparison on line 72 of src/pages/Index.tsx.

Changed `error.code ! "PGRST116"` to `error.code !== "PGRST116"` to use the correct JavaScript not-equal operator.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 56`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2648f5b307d34f43917573ddb1f76006/neon-garden)

👀 [Preview Link](https://2648f5b307d34f43917573ddb1f76006-neon-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2648f5b307d34f43917573ddb1f76006</projectId>-->
<!--<branchName>neon-garden</branchName>-->