### PR TITLE
Change default theme from system preference to sakura-love

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -35,14 +35,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       return savedTheme;
     }
 
-    // Default to system preference
-    if (
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-      return "dark";
-    }
-    return "light";
+    // Default to Sakura Love theme
+    return "sakura-love";
   });
 
   const currentTheme =


### PR DESCRIPTION
Replace system preference detection logic with direct return of "sakura-love" theme.

Changes:
- Remove window.matchMedia system preference detection
- Remove conditional logic for dark/light theme selection
- Set "sakura-love" as the default theme when no saved theme exists

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/a32529de6bd34ccfba77312892441762/glow-hub)

👀 [Preview Link](https://a32529de6bd34ccfba77312892441762-glow-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a32529de6bd34ccfba77312892441762</projectId>-->
<!--<branchName>glow-hub</branchName>-->