### PR TITLE
Remove maze, 2048, and fourpics games from lobby

### DIFF
--- a/src/components/games/ProfessionalGameLobby.tsx
+++ b/src/components/games/ProfessionalGameLobby.tsx
@@ -32,12 +32,9 @@ interface ProfessionalGameLobbyProps {
     gameType:
       | "chess"
       | "ludo"
-      | "maze"
-      | "game2048"
       | "math"
       | "wordsearch"
       | "codelearn"
-      | "fourpics"
       | "hangman"
       | "akinator",
   ) => void;
@@ -116,42 +113,7 @@ export const ProfessionalGameLobby: React.FC<ProfessionalGameLobbyProps> = ({
       highlight: true,
       priority: 3,
     },
-    {
-      id: "maze",
-      title: "Maze Explorer",
-      subtitle: "Puzzle Adventure",
-      description: "Navigate complex mazes and challenge your mind",
-      icon: Target,
-      category: "free",
-      gradient: "from-indigo-500 to-blue-600",
-      cardBg: "from-indigo-50 to-blue-50",
-      iconBg: "bg-indigo-100",
-      iconColor: "text-indigo-600",
-      players: "500+ Exploring",
-      status: "🧩 PUZZLE",
-      earning: "Free Play",
-      features: ["Brain Training", "Multiple Levels", "Achievements"],
-      highlight: false,
-      priority: 4,
-    },
-    {
-      id: "game2048",
-      title: "2048 Challenge",
-      subtitle: "Number Puzzle",
-      description: "Combine tiles to reach the ultimate 2048 goal",
-      icon: Gamepad2,
-      category: "free",
-      gradient: "from-cyan-500 to-blue-600",
-      cardBg: "from-cyan-50 to-blue-50",
-      iconBg: "bg-cyan-100",
-      iconColor: "text-cyan-600",
-      players: "300+ Playing",
-      status: "🎯 FOCUS",
-      earning: "Free Play",
-      features: ["3 Difficulty Modes", "Best Score", "Smooth Animations"],
-      highlight: false,
-      priority: 5,
-    },
+
     {
       id: "math",
       title: "Math Genius",
@@ -168,7 +130,7 @@ export const ProfessionalGameLobby: React.FC<ProfessionalGameLobbyProps> = ({
       earning: "Free Play",
       features: ["6 Question Types", "Timed Challenges", "Progress Stats"],
       highlight: false,
-      priority: 6,
+      priority: 4,
     },
     {
       id: "wordsearch",
@@ -186,26 +148,9 @@ export const ProfessionalGameLobby: React.FC<ProfessionalGameLobbyProps> = ({
       earning: "Coin Rewards",
       features: ["Multiplayer Mode", "Smart Hints", "Daily Rewards"],
       highlight: false,
-      priority: 7,
+      priority: 5,
     },
-    {
-      id: "fourpics",
-      title: "4 Pics 1 Word",
-      subtitle: "Visual Word Puzzle",
-      description: "Guess the word from four pictures and earn coins",
-      icon: Image,
-      category: "earn",
-      gradient: "from-orange-500 to-red-600",
-      cardBg: "from-orange-50 to-red-50",
-      iconBg: "bg-orange-100",
-      iconColor: "text-orange-600",
-      players: "80+ Playing",
-      status: "🖼️ NEW",
-      earning: "Coin Rewards",
-      features: ["99 Levels", "Smart Hints", "Visual Puzzles"],
-      highlight: false,
-      priority: 8,
-    },
+
     {
       id: "hangman",
       title: "Hangman Classic",
@@ -222,7 +167,7 @@ export const ProfessionalGameLobby: React.FC<ProfessionalGameLobbyProps> = ({
       earning: "Free Play",
       features: ["3 Difficulty Levels", "Word Categories", "Hints Available"],
       highlight: false,
-      priority: 9,
+      priority: 6,
     },
     {
       id: "akinator",
@@ -240,7 +185,7 @@ export const ProfessionalGameLobby: React.FC<ProfessionalGameLobbyProps> = ({
       earning: "Free Play",
       features: ["AI Mind Reading", "Smart Questions", "Character Database"],
       highlight: false,
-      priority: 10,
+      priority: 7,
     },
   ];
 

--- a/src/components/games/codelearn/CodeLearnLessonView.tsx
+++ b/src/components/games/codelearn/CodeLearnLessonView.tsx
@@ -126,6 +126,88 @@ export const CodeLearnLessonView: React.FC<CodeLearnLessonViewProps> = ({
     return () => clearInterval(interval);
   }, [startTime]);
 
+  // Handle terminal command execution
+  const handleTerminalExecute = async (
+    command: string,
+  ): Promise<string | { output: string; error?: string }> => {
+    const userCode = exerciseAnswers[currentExercise?.id || ""] || "";
+
+    // Simulate code execution based on the command and user's code
+    try {
+      if (command.startsWith("python ") && userCode) {
+        // Simulate Python execution
+        const output = simulatePythonExecution(userCode);
+        setTerminalOutput(output);
+        return { output };
+      } else if (command.startsWith("node ") && userCode) {
+        // Simulate JavaScript execution
+        const output = simulateJavaScriptExecution(userCode);
+        setTerminalOutput(output);
+        return { output };
+      } else if (command === "run" && userCode) {
+        // Generic run command
+        const output = simulateCodeExecution(
+          userCode,
+          currentExercise?.language || "python",
+        );
+        setTerminalOutput(output);
+        return { output };
+      } else {
+        return `Command executed: ${command}`;
+      }
+    } catch (error) {
+      return {
+        output: "",
+        error: `Error executing command: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  };
+
+  const simulatePythonExecution = (code: string): string => {
+    // Simple simulation of Python code execution
+    if (code.includes("print(")) {
+      const match = code.match(/print\(["'](.+?)["']\)/);
+      if (match) {
+        return match[1];
+      }
+    }
+    if (code.includes("Hello World") || code.includes("hello world")) {
+      return "Hello World";
+    }
+    if (code.includes("2 + 2") || code.includes("2+2")) {
+      return "4";
+    }
+    return "Code executed successfully!";
+  };
+
+  const simulateJavaScriptExecution = (code: string): string => {
+    // Simple simulation of JavaScript code execution
+    if (code.includes("console.log(")) {
+      const match = code.match(/console\.log\(["'](.+?)["']\)/);
+      if (match) {
+        return match[1];
+      }
+    }
+    if (code.includes("Hello World") || code.includes("hello world")) {
+      return "Hello World";
+    }
+    if (code.includes("2 + 2") || code.includes("2+2")) {
+      return "4";
+    }
+    return "Code executed successfully!";
+  };
+
+  const simulateCodeExecution = (code: string, language: string): string => {
+    switch (language) {
+      case "python":
+        return simulatePythonExecution(code);
+      case "javascript":
+        return simulateJavaScriptExecution(code);
+      default:
+        return "Code executed successfully!";
+    }
+  };
+
   // Handle answer submission with kid-friendly feedback
   const handleAnswerSubmit = () => {
     if (!currentExercise?.id || !exerciseAnswers[currentExercise.id]) {

--- a/src/components/games/codelearn/CodeLearnLessonView.tsx
+++ b/src/components/games/codelearn/CodeLearnLessonView.tsx
@@ -103,6 +103,8 @@ export const CodeLearnLessonView: React.FC<CodeLearnLessonViewProps> = ({
   const [hearts, setHearts] = useState(3); // Lives system for kids
   const [streakCount, setStreakCount] = useState(0);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [terminalOutput, setTerminalOutput] = useState<string>("");
+  const [showTerminal, setShowTerminal] = useState(false);
 
   const currentExercise = lesson?.content?.exercises?.[currentExerciseIndex];
   const isLastExercise =

--- a/src/components/games/codelearn/CodeLearnLessonView.tsx
+++ b/src/components/games/codelearn/CodeLearnLessonView.tsx
@@ -526,18 +526,56 @@ export const CodeLearnLessonView: React.FC<CodeLearnLessonViewProps> = ({
             </CardHeader>
             <CardContent className="space-y-4">
               {currentExercise?.type === "code" ? (
-                <Textarea
-                  placeholder="Write your code here... 🚀"
-                  value={exerciseAnswers[currentExercise?.id || ""] || ""}
-                  onChange={(e) =>
-                    setExerciseAnswers({
-                      ...exerciseAnswers,
-                      [currentExercise?.id || ""]: e.target.value,
-                    })
-                  }
-                  className="font-mono text-sm min-h-[200px] bg-gray-50 border-2 border-gray-200 rounded-xl"
-                  disabled={showExplanation}
-                />
+                <div className="space-y-4">
+                  <Textarea
+                    placeholder="Write your code here... 🚀"
+                    value={exerciseAnswers[currentExercise?.id || ""] || ""}
+                    onChange={(e) =>
+                      setExerciseAnswers({
+                        ...exerciseAnswers,
+                        [currentExercise?.id || ""]: e.target.value,
+                      })
+                    }
+                    className="font-mono text-sm min-h-[200px] bg-gray-50 border-2 border-gray-200 rounded-xl"
+                    disabled={showExplanation}
+                  />
+
+                  {/* Terminal Toggle Button */}
+                  <div className="flex gap-2">
+                    <Button
+                      onClick={() => setShowTerminal(!showTerminal)}
+                      variant="outline"
+                      className="bg-gray-900 text-green-400 border-gray-700 hover:bg-gray-800"
+                    >
+                      <Terminal className="w-4 h-4 mr-2" />
+                      {showTerminal ? "Hide Terminal" : "Show Terminal"}
+                    </Button>
+
+                    {exerciseAnswers[currentExercise?.id || ""] && (
+                      <Button
+                        onClick={() => {
+                          if (!showTerminal) setShowTerminal(true);
+                          handleTerminalExecute("run");
+                        }}
+                        variant="outline"
+                        className="bg-green-600 text-white hover:bg-green-700"
+                      >
+                        <Play className="w-4 h-4 mr-2" />
+                        Run Code
+                      </Button>
+                    )}
+                  </div>
+
+                  {/* Terminal Component */}
+                  {showTerminal && (
+                    <CodeTerminal
+                      onExecute={handleTerminalExecute}
+                      initialMessage="Welcome to Code Terminal! Type 'run' to execute your code, or try other commands."
+                      disabled={showExplanation}
+                      className="mt-4"
+                    />
+                  )}
+                </div>
               ) : (
                 <Input
                   placeholder="Type your answer here... ✨"

--- a/src/components/games/codelearn/CodeLearnLessonView.tsx
+++ b/src/components/games/codelearn/CodeLearnLessonView.tsx
@@ -25,8 +25,10 @@ import {
   Trophy,
   Sparkles,
   Rocket,
+  Terminal,
 } from "lucide-react";
 import { CodeLesson, CodeUnit, UserProgress, Exercise } from "./CodeLearnTypes";
+import { CodeTerminal } from "./CodeTerminal";
 import { toast } from "sonner";
 
 interface CodeLearnLessonViewProps {

--- a/src/components/games/codelearn/CodeTerminal.tsx
+++ b/src/components/games/codelearn/CodeTerminal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Terminal, Play, Clear, Copy, Check } from "lucide-react";
+import { Terminal, Play, Trash2, Copy, Check } from "lucide-react";
 import { toast } from "sonner";
 
 interface TerminalLine {

--- a/src/components/games/codelearn/CodeTerminal.tsx
+++ b/src/components/games/codelearn/CodeTerminal.tsx
@@ -1,0 +1,378 @@
+import React, { useState, useRef, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Terminal, Play, Clear, Copy, Check } from "lucide-react";
+import { toast } from "sonner";
+
+interface TerminalLine {
+  type: "input" | "output" | "error" | "system";
+  content: string;
+  timestamp?: number;
+}
+
+interface CodeTerminalProps {
+  onExecute?: (
+    command: string,
+  ) => Promise<string | { output: string; error?: string }>;
+  initialMessage?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const CodeTerminal: React.FC<CodeTerminalProps> = ({
+  onExecute,
+  initialMessage = "Welcome to Code Terminal! Type your commands below.",
+  disabled = false,
+  className = "",
+}) => {
+  const [lines, setLines] = useState<TerminalLine[]>([
+    {
+      type: "system",
+      content: initialMessage,
+      timestamp: Date.now(),
+    },
+  ]);
+  const [currentInput, setCurrentInput] = useState("");
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [commandHistory, setCommandHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [copied, setCopied] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const terminalRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when new lines are added
+  useEffect(() => {
+    if (terminalRef.current) {
+      terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+    }
+  }, [lines]);
+
+  // Focus input when terminal is clicked
+  useEffect(() => {
+    if (inputRef.current && !disabled) {
+      inputRef.current.focus();
+    }
+  }, [disabled]);
+
+  const addLine = (line: TerminalLine) => {
+    setLines((prev) => [...prev, { ...line, timestamp: Date.now() }]);
+  };
+
+  const handleExecute = async () => {
+    if (!currentInput.trim() || isExecuting) return;
+
+    const command = currentInput.trim();
+
+    // Add input to terminal
+    addLine({
+      type: "input",
+      content: `$ ${command}`,
+    });
+
+    // Add to command history
+    setCommandHistory((prev) => [...prev, command]);
+    setHistoryIndex(-1);
+    setCurrentInput("");
+    setIsExecuting(true);
+
+    try {
+      if (onExecute) {
+        const result = await onExecute(command);
+
+        if (typeof result === "string") {
+          addLine({
+            type: "output",
+            content: result,
+          });
+        } else {
+          if (result.output) {
+            addLine({
+              type: "output",
+              content: result.output,
+            });
+          }
+          if (result.error) {
+            addLine({
+              type: "error",
+              content: result.error,
+            });
+          }
+        }
+      } else {
+        // Default behavior for common commands
+        await handleDefaultCommands(command);
+      }
+    } catch (error) {
+      addLine({
+        type: "error",
+        content: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+      });
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  const handleDefaultCommands = async (command: string): Promise<void> => {
+    const cmd = command.toLowerCase().trim();
+
+    // Simulate command execution delay
+    await new Promise((resolve) =>
+      setTimeout(resolve, 300 + Math.random() * 700),
+    );
+
+    switch (cmd) {
+      case "help":
+        addLine({
+          type: "output",
+          content: `Available commands:
+• help - Show this help message
+• clear - Clear the terminal
+• echo [text] - Print text to terminal
+• date - Show current date and time
+• whoami - Show current user
+• pwd - Show current directory
+• ls - List directory contents`,
+        });
+        break;
+
+      case "clear":
+        setLines([
+          {
+            type: "system",
+            content: initialMessage,
+            timestamp: Date.now(),
+          },
+        ]);
+        break;
+
+      case "date":
+        addLine({
+          type: "output",
+          content: new Date().toLocaleString(),
+        });
+        break;
+
+      case "whoami":
+        addLine({
+          type: "output",
+          content: "codelearner",
+        });
+        break;
+
+      case "pwd":
+        addLine({
+          type: "output",
+          content: "/home/codelearner/workspace",
+        });
+        break;
+
+      case "ls":
+        addLine({
+          type: "output",
+          content: `total 4
+drwxr-xr-x 2 codelearner codelearner 4096 $(date +%b) $(date +%d) $(date +%H:%M) .
+drwxr-xr-x 3 codelearner codelearner 4096 $(date +%b) $(date +%d) $(date +%H:%M) ..
+-rw-r--r-- 1 codelearner codelearner  123 $(date +%b) $(date +%d) $(date +%H:%M) main.py
+-rw-r--r-- 1 codelearner codelearner   45 $(date +%b) $(date +%d) $(date +%H:%M) README.md`,
+        });
+        break;
+
+      default:
+        if (cmd.startsWith("echo ")) {
+          const text = command.substring(5);
+          addLine({
+            type: "output",
+            content: text,
+          });
+        } else if (
+          cmd.startsWith("python ") ||
+          cmd.startsWith("node ") ||
+          cmd.startsWith("java ")
+        ) {
+          addLine({
+            type: "output",
+            content: "Code execution simulated successfully! ✅",
+          });
+        } else {
+          addLine({
+            type: "error",
+            content: `Command '${command}' not found. Type 'help' for available commands.`,
+          });
+        }
+        break;
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleExecute();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (commandHistory.length > 0) {
+        const newIndex =
+          historyIndex === -1
+            ? commandHistory.length - 1
+            : Math.max(0, historyIndex - 1);
+        setHistoryIndex(newIndex);
+        setCurrentInput(commandHistory[newIndex]);
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (historyIndex !== -1) {
+        const newIndex = historyIndex + 1;
+        if (newIndex >= commandHistory.length) {
+          setHistoryIndex(-1);
+          setCurrentInput("");
+        } else {
+          setHistoryIndex(newIndex);
+          setCurrentInput(commandHistory[newIndex]);
+        }
+      }
+    }
+  };
+
+  const clearTerminal = () => {
+    setLines([
+      {
+        type: "system",
+        content: initialMessage,
+        timestamp: Date.now(),
+      },
+    ]);
+  };
+
+  const copyTerminalContent = async () => {
+    const content = lines.map((line) => line.content).join("\n");
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      toast.success("Terminal content copied!");
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      toast.error("Failed to copy content");
+    }
+  };
+
+  const getLineColor = (type: TerminalLine["type"]) => {
+    switch (type) {
+      case "input":
+        return "text-cyan-400";
+      case "output":
+        return "text-green-400";
+      case "error":
+        return "text-red-400";
+      case "system":
+        return "text-yellow-400";
+      default:
+        return "text-gray-300";
+    }
+  };
+
+  return (
+    <Card className={`bg-gray-900 border-gray-700 ${className}`}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-green-400">
+            <Terminal className="w-5 h-5" />
+            Code Terminal
+          </CardTitle>
+          <div className="flex gap-2">
+            <Button
+              onClick={copyTerminalContent}
+              variant="ghost"
+              size="sm"
+              className="text-gray-400 hover:text-white hover:bg-gray-700"
+            >
+              {copied ? (
+                <Check className="w-4 h-4" />
+              ) : (
+                <Copy className="w-4 h-4" />
+              )}
+            </Button>
+            <Button
+              onClick={clearTerminal}
+              variant="ghost"
+              size="sm"
+              className="text-gray-400 hover:text-white hover:bg-gray-700"
+            >
+              <Clear className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {/* Terminal Output */}
+        <div
+          ref={terminalRef}
+          className="h-64 overflow-y-auto bg-black/50 px-4 py-2 font-mono text-sm"
+          onClick={() => inputRef.current?.focus()}
+        >
+          {lines.map((line, index) => (
+            <div
+              key={index}
+              className={`${getLineColor(line.type)} leading-relaxed`}
+            >
+              <pre className="whitespace-pre-wrap font-mono">
+                {line.content}
+              </pre>
+            </div>
+          ))}
+
+          {/* Current input line */}
+          {!disabled && (
+            <div className="flex items-center text-cyan-400 mt-1">
+              <span className="mr-2">$</span>
+              <Input
+                ref={inputRef}
+                value={currentInput}
+                onChange={(e) => setCurrentInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="bg-transparent border-none text-cyan-400 font-mono text-sm p-0 h-auto focus:ring-0 placeholder:text-gray-500"
+                placeholder={isExecuting ? "Executing..." : "Type a command..."}
+                disabled={disabled || isExecuting}
+                autoComplete="off"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Input Controls */}
+        <div className="p-4 border-t border-gray-700 bg-gray-800/50">
+          <div className="flex gap-2">
+            <div className="flex-1 flex items-center gap-2">
+              <span className="text-gray-400 font-mono text-sm">$</span>
+              <Input
+                value={currentInput}
+                onChange={(e) => setCurrentInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="bg-gray-800 border-gray-600 text-white font-mono text-sm focus:border-cyan-400"
+                placeholder={
+                  isExecuting ? "Executing..." : "Type your command here..."
+                }
+                disabled={disabled || isExecuting}
+                autoComplete="off"
+              />
+            </div>
+            <Button
+              onClick={handleExecute}
+              disabled={disabled || isExecuting || !currentInput.trim()}
+              className="bg-green-600 hover:bg-green-700 text-white"
+              size="sm"
+            >
+              <Play className="w-4 h-4 mr-1" />
+              Run
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-4 mt-2 text-xs text-gray-400">
+            <span>Press Enter to execute</span>
+            <span>↑/↓ for command history</span>
+            <span>{commandHistory.length} commands in history</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/games/codelearn/CodeTerminal.tsx
+++ b/src/components/games/codelearn/CodeTerminal.tsx
@@ -297,7 +297,7 @@ drwxr-xr-x 3 codelearner codelearner 4096 $(date +%b) $(date +%d) $(date +%H:%M)
               size="sm"
               className="text-gray-400 hover:text-white hover:bg-gray-700"
             >
-              <Clear className="w-4 h-4" />
+              <Trash2 className="w-4 h-4" />
             </Button>
           </div>
         </div>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -35,14 +35,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       return savedTheme;
     }
 
-    // Default to system preference
-    if (
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-      return "dark";
-    }
-    return "light";
+    // Default to Sakura Love theme for new users
+    return "sakura-love";
   });
 
   const currentTheme =


### PR DESCRIPTION
This pull request removes three games from the professional game lobby:

- Removed "maze" game type from the gameType union type
- Removed "game2048" game type from the gameType union type  
- Removed "fourpics" game type from the gameType union type
- Deleted the complete game configuration objects for Maze Explorer, 2048 Challenge, and 4 Pics 1 Word
- Updated priority values for remaining games (Math Genius: 6→4, Word Search: 7→5, Hangman: 9→6, Akinator: 10→7)

Additional changes:
- Added CodeTerminal component import and terminal functionality to CodeLearnLessonView
- Added terminal state management with output display and command execution
- Added terminal toggle button and run functionality for code exercises
- Changed default theme from system preference to "sakura-love" in ThemeContext

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/420a499d81a344b199cfa897ad8473ea/zenith-nest)

👀 [Preview Link](https://420a499d81a344b199cfa897ad8473ea-zenith-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>420a499d81a344b199cfa897ad8473ea</projectId>-->
<!--<branchName>zenith-nest</branchName>-->